### PR TITLE
Fix backend env loading from schemas folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,10 @@ An interactive daily routine tracker inspired by the Fitplan dashboard aesthetic
    source .venv/bin/activate
    pip install -r requirements.txt
    ```
-2. Run the API with Uvicorn:
+2. Copy `example.env` to `.env` and update the values. The backend will automatically
+   read environment variables from `.env` files located at either the repository root or
+   within `api/schemas/.env`.
+3. Run the API with Uvicorn:
    ```bash
    uvicorn app.main:app --reload --port 8000
    ```

--- a/api/app/config.py
+++ b/api/app/config.py
@@ -1,7 +1,38 @@
+from __future__ import annotations
+
 import os
+from pathlib import Path
+
 from dotenv import load_dotenv
 
-load_dotenv()
+
+def _load_env() -> None:
+    """Load environment variables from common backend .env locations."""
+
+    base_dir = Path(__file__).resolve().parent
+    candidates: list[Path] = [
+        base_dir.parent / "schemas" / ".env",  # api/schemas/.env
+        base_dir / "schemas" / ".env",  # api/app/schemas/.env (fallback)
+        base_dir / ".env",  # api/app/.env
+        base_dir.parent / ".env",  # api/.env
+        Path.cwd() / ".env",  # project root when running from repo root
+    ]
+
+    loaded = False
+    seen: set[Path] = set()
+    for candidate in candidates:
+        resolved = candidate.resolve()
+        if resolved in seen or not resolved.exists():
+            continue
+        load_dotenv(resolved, override=False)
+        seen.add(resolved)
+        loaded = True
+
+    if not loaded:
+        load_dotenv()
+
+
+_load_env()
 
 MONGO_URI: str = os.getenv("MONGO_URI", "mongodb://localhost:27017")
 # Use your real DB name, or keep default if you made one with that name:


### PR DESCRIPTION
## Summary
- load backend environment variables from common .env locations including api/schemas/.env
- document the supported .env locations in the backend setup instructions

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dcd316ae508326b6b5724eecf0ad18