### PR TITLE
Fix frontend API base path configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ An interactive daily routine tracker inspired by the Fitplan dashboard aesthetic
    echo "VITE_DEMO_USER_ID=your-demo-user-id" >> .env
    ```
 
+   > The frontend automatically appends `/v1` to the configured API URL, so point
+   > `VITE_API_URL` to the root of your FastAPI server.
+
 3. Start the Vite dev server:
    ```bash
    npm run dev

--- a/example.env
+++ b/example.env
@@ -39,5 +39,5 @@ MONGODB_GROUPS_COLLECTION=social_groups
 ########################################
 
 # Base URLs consumed by the React client for REST and WebSocket traffic.
-VITE_API_BASE_URL=http://localhost:8000
+VITE_API_URL=http://localhost:8000
 VITE_SOCKET_BASE_URL=http://localhost:8000

--- a/frontend/src/lib/api-client.ts
+++ b/frontend/src/lib/api-client.ts
@@ -1,8 +1,13 @@
 import axios from 'axios';
 import { env } from './env';
 
+const buildBaseUrl = () => {
+  const sanitized = env.API_URL.replace(/\/$/, '');
+  return sanitized.endsWith('/v1') ? sanitized : `${sanitized}/v1`;
+};
+
 export const api = axios.create({
-  baseURL: env.API_URL,
+  baseURL: buildBaseUrl(),
 });
 
 api.interceptors.response.use(

--- a/frontend/src/lib/env.ts
+++ b/frontend/src/lib/env.ts
@@ -1,4 +1,16 @@
+const resolveApiUrl = () => {
+  const rawUrl =
+    (import.meta.env.VITE_API_URL as string | undefined) ??
+    (import.meta.env.VITE_API_BASE_URL as string | undefined);
+
+  if (!rawUrl || rawUrl.trim().length === 0) {
+    return 'http://localhost:8000';
+  }
+
+  return rawUrl;
+};
+
 export const env = {
-  API_URL: import.meta.env.VITE_API_URL as string,
+  API_URL: resolveApiUrl(),
   DEMO_USER_ID: import.meta.env.VITE_DEMO_USER_ID as string,
 };


### PR DESCRIPTION
## Summary
- ensure the frontend resolves the API base URL with sensible defaults
- automatically target the versioned `/v1` REST endpoints from the axios client
- document the configuration updates in the README and environment template

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd4d1d16548326b390ad36c1438ce3