### PR TITLE
Add backend compatibility routes for unversioned clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,21 @@ An interactive daily routine tracker inspired by the Fitplan dashboard aesthetic
    curl http://localhost:8000/health/live
    ```
 
+### API Versioning & Demo Aliases
+- The FastAPI routers are mounted at both the root (e.g. `/tasks`) and the
+  versioned `/v1` prefix so existing clients continue to work during the
+  migration.
+- Habit log routes now respond to both `/habit-logs` and `/habit_logs` for
+  compatibility.
+- If you rely on the seeded demo data, map any friendly identifiers to the
+  MongoDB ObjectId stored in your database by setting these variables in
+  `api/.env`:
+  ```bash
+  echo "DEMO_USER_ALIAS=wendy" >> api/.env
+  echo "DEMO_USER_ID=68dcaa1e450fee4dd3d6b17b" >> api/.env
+  # or provide multiple entries: DEMO_USER_ALIASES=wendy:68dc...,alex:...
+  ```
+
 ### Frontend Setup
 1. Install Node dependencies:
    ```bash
@@ -56,6 +71,10 @@ An interactive daily routine tracker inspired by the Fitplan dashboard aesthetic
    echo "VITE_API_URL=http://localhost:8000" > .env
    echo "VITE_DEMO_USER_ID=your-demo-user-id" >> .env
    ```
+
+   > The frontend automatically targets the `/v1` API routes, so you can point
+   > `VITE_API_URL` at the root of your FastAPI server (with or without a
+   > trailing slash or `/v1`).
 
 3. Start the Vite dev server:
    ```bash

--- a/api/app/config.py
+++ b/api/app/config.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
+from typing import Dict
 
 from dotenv import load_dotenv
 
@@ -43,3 +44,30 @@ API_CORS_ORIGINS: list[str] = [
     for o in os.getenv("API_CORS_ORIGINS", "").split(",")
     if o.strip()
 ]
+
+
+def _parse_alias_map(raw: str) -> Dict[str, str]:
+    mapping: Dict[str, str] = {}
+    for chunk in raw.split(","):
+        if ":" not in chunk:
+            continue
+        alias, target = chunk.split(":", 1)
+        alias_key = alias.strip()
+        target_value = target.strip()
+        if alias_key and target_value:
+            mapping[alias_key] = target_value
+    return mapping
+
+
+_alias_map = _parse_alias_map(os.getenv("DEMO_USER_ALIASES", ""))
+if not _alias_map:
+    default_alias = os.getenv("DEMO_USER_ALIAS", "wendy")
+    default_target = os.getenv("DEMO_USER_ID", "68dcaa1e450fee4dd3d6b17b")
+    if default_alias and default_target:
+        _alias_map[default_alias] = default_target
+
+for alias, target in list(_alias_map.items()):
+    _alias_map.setdefault(target, target)
+
+DEMO_USER_ALIASES: Dict[str, str] = _alias_map
+

--- a/api/app/utils/__init__.py
+++ b/api/app/utils/__init__.py
@@ -1,0 +1,5 @@
+"""Utility helpers for the DailyRoutine backend."""
+
+from .object_ids import InvalidObjectId, resolve_object_id
+
+__all__ = ["InvalidObjectId", "resolve_object_id"]

--- a/api/app/utils/object_ids.py
+++ b/api/app/utils/object_ids.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from typing import Dict
+
+from bson import ObjectId
+
+from ..config import DEMO_USER_ALIASES
+
+
+class InvalidObjectId(ValueError):
+    """Raised when a value cannot be resolved to a valid ObjectId."""
+
+
+def _normalize_aliases(mapping: Dict[str, str]) -> Dict[str, str]:
+    normalized: Dict[str, str] = {}
+    for alias, target in mapping.items():
+        alias_key = alias.strip()
+        target_value = target.strip()
+        if not alias_key or not target_value:
+            continue
+        normalized[alias_key] = target_value
+        normalized.setdefault(target_value, target_value)
+    return normalized
+
+
+_ALIAS_MAP = _normalize_aliases(DEMO_USER_ALIASES)
+
+
+def resolve_object_id(value: str, field: str) -> ObjectId:
+    """Resolve a potentially aliased identifier into an ObjectId."""
+
+    candidate = value.strip()
+    if not candidate:
+        raise InvalidObjectId(f"Missing {field}")
+
+    mapped = _ALIAS_MAP.get(candidate, candidate)
+    if ObjectId.is_valid(mapped):
+        return ObjectId(mapped)
+
+    raise InvalidObjectId(f"Invalid {field}")
+
+
+__all__ = ["InvalidObjectId", "resolve_object_id"]

--- a/api/habits.py
+++ b/api/habits.py
@@ -14,13 +14,20 @@ else:  # pragma: no cover - handles ``uvicorn main:app`` when cwd==api/
     from app.schemas.common import ListResponse
     from app.schemas.habit import Habit, HabitCreate
 
-router = APIRouter(prefix="/v1/habits", tags=["habits"])
+if __package__:
+    from .app.utils.object_ids import resolve_object_id
+else:  # pragma: no cover
+    from app.utils.object_ids import resolve_object_id
+
+
+router = APIRouter(prefix="/habits", tags=["habits"])
 
 
 def _parse_object_id(value: str, field: str) -> ObjectId:
-    if not ObjectId.is_valid(value):
-        raise HTTPException(status_code=400, detail=f"Invalid {field}")
-    return ObjectId(value)
+    try:
+        return resolve_object_id(value, field)
+    except ValueError as exc:  # pragma: no cover - defensive guard
+        raise HTTPException(status_code=400, detail=f"Invalid {field}") from exc
 
 
 @router.post("", response_model=Habit, status_code=201)

--- a/api/health.py
+++ b/api/health.py
@@ -1,9 +1,14 @@
 # health.py
 from fastapi import APIRouter
 
-router = APIRouter(prefix="/v1/health", tags=["health"])
+router = APIRouter(prefix="/health", tags=["health"])
 
 
-@router.get("")
-async def health():
+@router.get("", include_in_schema=False)
+async def health_root():
+    return {"ok": True}
+
+
+@router.get("/live")
+async def health_live():
     return {"ok": True}

--- a/api/schedule.py
+++ b/api/schedule.py
@@ -15,13 +15,20 @@ else:  # pragma: no cover - handles ``uvicorn main:app`` when cwd==api/
     from app.schemas.common import ListResponse
     from app.schemas.schedule_event import ScheduleEvent, ScheduleEventCreate
 
-router = APIRouter(prefix="/v1/schedule-events", tags=["schedule"])
+if __package__:
+    from .app.utils.object_ids import resolve_object_id
+else:  # pragma: no cover
+    from app.utils.object_ids import resolve_object_id
+
+
+router = APIRouter(prefix="/schedule-events", tags=["schedule"])
 
 
 def _parse_object_id(value: str, field: str) -> ObjectId:
-    if not ObjectId.is_valid(value):
-        raise HTTPException(status_code=400, detail=f"Invalid {field}")
-    return ObjectId(value)
+    try:
+        return resolve_object_id(value, field)
+    except ValueError as exc:  # pragma: no cover - defensive guard
+        raise HTTPException(status_code=400, detail=f"Invalid {field}") from exc
 
 
 @router.post("", response_model=ScheduleEvent, status_code=201)

--- a/api/users.py
+++ b/api/users.py
@@ -12,13 +12,20 @@ else:  # pragma: no cover - handles ``uvicorn main:app`` when cwd==api/
     from app.db import get_db
     from app.schemas.user import User, UserCreate
 
-router = APIRouter(prefix="/v1/users", tags=["users"])
+if __package__:
+    from .app.utils.object_ids import resolve_object_id
+else:  # pragma: no cover
+    from app.utils.object_ids import resolve_object_id
+
+
+router = APIRouter(prefix="/users", tags=["users"])
 
 
 def _parse_object_id(value: str, field: str) -> ObjectId:
-    if not ObjectId.is_valid(value):
-        raise HTTPException(status_code=400, detail=f"Invalid {field}")
-    return ObjectId(value)
+    try:
+        return resolve_object_id(value, field)
+    except ValueError as exc:  # pragma: no cover - defensive guard
+        raise HTTPException(status_code=400, detail=f"Invalid {field}") from exc
 
 
 @router.post("", response_model=User, status_code=201)

--- a/example.env
+++ b/example.env
@@ -30,6 +30,12 @@ MONGODB_TASKS_COLLECTION=tasks
 MONGODB_EVENTS_COLLECTION=schedule_events
 MONGODB_GROUPS_COLLECTION=social_groups
 
+# Optional alias mapping for demo or fixture data. Provide either a single
+# alias/ID pair or a comma separated list (e.g. `wendy:68dc...,alex:...`).
+DEMO_USER_ALIAS=wendy
+DEMO_USER_ID=68dcaa1e450fee4dd3d6b17b
+# DEMO_USER_ALIASES=wendy:68dcaa1e450fee4dd3d6b17b
+
 # Optional: provide a separate database for testing or temporary experiments.
 # TEST_MONGODB_URI=mongodb://localhost:27017
 # TEST_MONGODB_DB_NAME=daily_routine_test
@@ -39,5 +45,5 @@ MONGODB_GROUPS_COLLECTION=social_groups
 ########################################
 
 # Base URLs consumed by the React client for REST and WebSocket traffic.
-VITE_API_BASE_URL=http://localhost:8000
+VITE_API_URL=http://localhost:8000
 VITE_SOCKET_BASE_URL=http://localhost:8000

--- a/frontend/src/lib/api-client.ts
+++ b/frontend/src/lib/api-client.ts
@@ -1,8 +1,49 @@
 import axios from 'axios';
 import { env } from './env';
 
+const API_PREFIX = '/v1';
+
+const removeTrailingSlashes = (value: string) => value.replace(/\/+$/, '');
+
+const normalizeBaseUrl = (value: string) => {
+  const trimmed = removeTrailingSlashes(value.trim());
+  if (!trimmed) {
+    return 'http://localhost:8000';
+  }
+
+  if (trimmed.endsWith(API_PREFIX)) {
+    const withoutPrefix = removeTrailingSlashes(
+      trimmed.slice(0, -API_PREFIX.length)
+    );
+    return withoutPrefix || trimmed;
+  }
+
+  return trimmed;
+};
+
+const isAbsoluteUrl = (value: string) => /^[a-z][a-z0-9+.-]*:/.test(value);
+
 export const api = axios.create({
-  baseURL: env.API_URL,
+  baseURL: normalizeBaseUrl(env.API_URL),
+});
+
+api.interceptors.request.use((config) => {
+  if (typeof config.url === 'string' && !isAbsoluteUrl(config.url)) {
+    const normalizedPath = config.url.startsWith('/')
+      ? config.url
+      : `/${config.url}`;
+
+    if (
+      normalizedPath === API_PREFIX ||
+      normalizedPath.startsWith(`${API_PREFIX}/`)
+    ) {
+      config.url = normalizedPath;
+    } else {
+      config.url = `${API_PREFIX}${normalizedPath}`;
+    }
+  }
+
+  return config;
 });
 
 api.interceptors.response.use(

--- a/frontend/src/lib/env.ts
+++ b/frontend/src/lib/env.ts
@@ -1,4 +1,16 @@
+const resolveApiUrl = () => {
+  const rawUrl =
+    (import.meta.env.VITE_API_URL as string | undefined) ??
+    (import.meta.env.VITE_API_BASE_URL as string | undefined);
+
+  if (!rawUrl || rawUrl.trim().length === 0) {
+    return 'http://localhost:8000';
+  }
+
+  return rawUrl;
+};
+
 export const env = {
-  API_URL: import.meta.env.VITE_API_URL as string,
+  API_URL: resolveApiUrl(),
   DEMO_USER_ID: import.meta.env.VITE_DEMO_USER_ID as string,
 };


### PR DESCRIPTION
## Summary
- mount the FastAPI routers at both the root and `/v1` while exposing `/habit_logs` alongside `/habit-logs` for habit log lookups
- add a shared ObjectId resolver that maps friendly demo aliases to Mongo ids and reuse it across the resource routers
- document the alias environment variables in the README and sample env file so seeded data resolves correctly

## Testing
- python -m compileall api/


------
https://chatgpt.com/codex/tasks/task_e_68dd4d1d16548326b390ad36c1438ce3