### PR TITLE
Add Alexa integration scaffolding and backend summary endpoints

### DIFF
--- a/alexa/interaction-model/en-US.json
+++ b/alexa/interaction-model/en-US.json
@@ -1,0 +1,49 @@
+{
+  "interactionModel": {
+    "languageModel": {
+      "invocationName": "daily routine",
+      "intents": [
+        { "name": "AMAZON.HelpIntent", "samples": [] },
+        { "name": "AMAZON.StopIntent", "samples": [] },
+        { "name": "AMAZON.CancelIntent", "samples": [] },
+        {
+          "name": "TaskIntent",
+          "slots": [{ "name": "freeText", "type": "AMAZON.SearchQuery" }],
+          "samples": [
+            "add task {freeText}",
+            "complete task {freeText}",
+            "list my tasks",
+            "what tasks do I have"
+          ]
+        },
+        {
+          "name": "HabitIntent",
+          "slots": [{ "name": "freeText", "type": "AMAZON.SearchQuery" }],
+          "samples": [
+            "log habit {freeText}",
+            "check habit streak",
+            "how is my habit streak"
+          ]
+        },
+        {
+          "name": "ScheduleIntent",
+          "slots": [{ "name": "freeText", "type": "AMAZON.SearchQuery" }],
+          "samples": [
+            "what's my schedule",
+            "what do I have today",
+            "add event {freeText}"
+          ]
+        },
+        {
+          "name": "SummaryIntent",
+          "samples": [
+            "daily briefing",
+            "how am I doing",
+            "give me my daily summary"
+          ]
+        }
+      ],
+      "types": []
+    }
+  }
+}

--- a/alexa/lambda/fixtures/habit_log.json
+++ b/alexa/lambda/fixtures/habit_log.json
@@ -1,0 +1,28 @@
+{
+  "version": "1.0",
+  "session": {
+    "new": false,
+    "sessionId": "SessionId.habit_log",
+    "application": { "applicationId": "amzn1.ask.skill.test" },
+    "attributes": {},
+    "user": { "userId": "amzn1.ask.account.test" }
+  },
+  "context": {},
+  "request": {
+    "type": "IntentRequest",
+    "requestId": "EdwRequestId.habit_log",
+    "timestamp": "2024-01-01T00:00:03Z",
+    "locale": "en-US",
+    "intent": {
+      "name": "HabitIntent",
+      "confirmationStatus": "NONE",
+      "slots": {
+        "freeText": {
+          "name": "freeText",
+          "value": "log habit meditation",
+          "confirmationStatus": "NONE"
+        }
+      }
+    }
+  }
+}

--- a/alexa/lambda/fixtures/habit_streak.json
+++ b/alexa/lambda/fixtures/habit_streak.json
@@ -1,0 +1,28 @@
+{
+  "version": "1.0",
+  "session": {
+    "new": false,
+    "sessionId": "SessionId.habit_streak",
+    "application": { "applicationId": "amzn1.ask.skill.test" },
+    "attributes": {},
+    "user": { "userId": "amzn1.ask.account.test" }
+  },
+  "context": {},
+  "request": {
+    "type": "IntentRequest",
+    "requestId": "EdwRequestId.habit_streak",
+    "timestamp": "2024-01-01T00:00:04Z",
+    "locale": "en-US",
+    "intent": {
+      "name": "HabitIntent",
+      "confirmationStatus": "NONE",
+      "slots": {
+        "freeText": {
+          "name": "freeText",
+          "value": "check habit streak",
+          "confirmationStatus": "NONE"
+        }
+      }
+    }
+  }
+}

--- a/alexa/lambda/fixtures/sched_add.json
+++ b/alexa/lambda/fixtures/sched_add.json
@@ -1,0 +1,28 @@
+{
+  "version": "1.0",
+  "session": {
+    "new": false,
+    "sessionId": "SessionId.sched_add",
+    "application": { "applicationId": "amzn1.ask.skill.test" },
+    "attributes": {},
+    "user": { "userId": "amzn1.ask.account.test" }
+  },
+  "context": {},
+  "request": {
+    "type": "IntentRequest",
+    "requestId": "EdwRequestId.sched_add",
+    "timestamp": "2024-01-01T00:00:06Z",
+    "locale": "en-US",
+    "intent": {
+      "name": "ScheduleIntent",
+      "confirmationStatus": "NONE",
+      "slots": {
+        "freeText": {
+          "name": "freeText",
+          "value": "add event dentist at 3 PM",
+          "confirmationStatus": "NONE"
+        }
+      }
+    }
+  }
+}

--- a/alexa/lambda/fixtures/sched_list.json
+++ b/alexa/lambda/fixtures/sched_list.json
@@ -1,0 +1,28 @@
+{
+  "version": "1.0",
+  "session": {
+    "new": false,
+    "sessionId": "SessionId.sched_list",
+    "application": { "applicationId": "amzn1.ask.skill.test" },
+    "attributes": {},
+    "user": { "userId": "amzn1.ask.account.test" }
+  },
+  "context": {},
+  "request": {
+    "type": "IntentRequest",
+    "requestId": "EdwRequestId.sched_list",
+    "timestamp": "2024-01-01T00:00:05Z",
+    "locale": "en-US",
+    "intent": {
+      "name": "ScheduleIntent",
+      "confirmationStatus": "NONE",
+      "slots": {
+        "freeText": {
+          "name": "freeText",
+          "value": "what's my schedule",
+          "confirmationStatus": "NONE"
+        }
+      }
+    }
+  }
+}

--- a/alexa/lambda/fixtures/summary.json
+++ b/alexa/lambda/fixtures/summary.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0",
+  "session": {
+    "new": false,
+    "sessionId": "SessionId.summary",
+    "application": { "applicationId": "amzn1.ask.skill.test" },
+    "attributes": {},
+    "user": { "userId": "amzn1.ask.account.test" }
+  },
+  "context": {},
+  "request": {
+    "type": "IntentRequest",
+    "requestId": "EdwRequestId.summary",
+    "timestamp": "2024-01-01T00:00:07Z",
+    "locale": "en-US",
+    "intent": {
+      "name": "SummaryIntent",
+      "confirmationStatus": "NONE"
+    }
+  }
+}

--- a/alexa/lambda/fixtures/task_add.json
+++ b/alexa/lambda/fixtures/task_add.json
@@ -1,0 +1,28 @@
+{
+  "version": "1.0",
+  "session": {
+    "new": true,
+    "sessionId": "SessionId.task_add",
+    "application": { "applicationId": "amzn1.ask.skill.test" },
+    "attributes": {},
+    "user": { "userId": "amzn1.ask.account.test" }
+  },
+  "context": {},
+  "request": {
+    "type": "IntentRequest",
+    "requestId": "EdwRequestId.task_add",
+    "timestamp": "2024-01-01T00:00:00Z",
+    "locale": "en-US",
+    "intent": {
+      "name": "TaskIntent",
+      "confirmationStatus": "NONE",
+      "slots": {
+        "freeText": {
+          "name": "freeText",
+          "value": "add task buy milk",
+          "confirmationStatus": "NONE"
+        }
+      }
+    }
+  }
+}

--- a/alexa/lambda/fixtures/task_complete.json
+++ b/alexa/lambda/fixtures/task_complete.json
@@ -1,0 +1,28 @@
+{
+  "version": "1.0",
+  "session": {
+    "new": false,
+    "sessionId": "SessionId.task_complete",
+    "application": { "applicationId": "amzn1.ask.skill.test" },
+    "attributes": {},
+    "user": { "userId": "amzn1.ask.account.test" }
+  },
+  "context": {},
+  "request": {
+    "type": "IntentRequest",
+    "requestId": "EdwRequestId.task_complete",
+    "timestamp": "2024-01-01T00:00:01Z",
+    "locale": "en-US",
+    "intent": {
+      "name": "TaskIntent",
+      "confirmationStatus": "NONE",
+      "slots": {
+        "freeText": {
+          "name": "freeText",
+          "value": "complete task buy milk",
+          "confirmationStatus": "NONE"
+        }
+      }
+    }
+  }
+}

--- a/alexa/lambda/fixtures/task_list.json
+++ b/alexa/lambda/fixtures/task_list.json
@@ -1,0 +1,28 @@
+{
+  "version": "1.0",
+  "session": {
+    "new": false,
+    "sessionId": "SessionId.task_list",
+    "application": { "applicationId": "amzn1.ask.skill.test" },
+    "attributes": {},
+    "user": { "userId": "amzn1.ask.account.test" }
+  },
+  "context": {},
+  "request": {
+    "type": "IntentRequest",
+    "requestId": "EdwRequestId.task_list",
+    "timestamp": "2024-01-01T00:00:02Z",
+    "locale": "en-US",
+    "intent": {
+      "name": "TaskIntent",
+      "confirmationStatus": "NONE",
+      "slots": {
+        "freeText": {
+          "name": "freeText",
+          "value": "list my tasks",
+          "confirmationStatus": "NONE"
+        }
+      }
+    }
+  }
+}

--- a/alexa/lambda/handler.py
+++ b/alexa/lambda/handler.py
@@ -1,0 +1,185 @@
+import json
+import os
+import urllib.parse
+import urllib.request
+
+from ask_sdk_core.dispatch_components import AbstractRequestHandler
+from ask_sdk_core.handler_input import HandlerInput
+from ask_sdk_core.skill_builder import SkillBuilder
+from ask_sdk_core.utils import is_intent_name
+
+API_BASE = os.getenv("API_BASE")
+FIXED_USER_ID = os.getenv("FIXED_USER_ID", "wendy")
+TIMEOUT_SEC = float(os.getenv("HTTP_TIMEOUT", "6.0"))
+
+
+def _api(path: str, method: str = "GET", body: dict | None = None):
+    if not API_BASE:
+        raise RuntimeError("API_BASE environment variable must be set")
+    url = f"{API_BASE}{path}"
+    req = urllib.request.Request(url, method=method)
+    req.add_header("Content-Type", "application/json")
+    data = json.dumps(body).encode("utf-8") if body else None
+    with urllib.request.urlopen(req, data=data, timeout=TIMEOUT_SEC) as resp:
+        return json.loads(resp.read().decode("utf-8"))
+
+
+def _slot(hi: HandlerInput, name: str) -> str:
+    try:
+        return hi.request_envelope.request.intent.slots[name].value or ""
+    except Exception:
+        return ""
+
+
+class TaskIntentHandler(AbstractRequestHandler):
+    def can_handle(self, handler_input):
+        return is_intent_name("TaskIntent")(handler_input)
+
+    def handle(self, handler_input):
+        spoken = (_slot(handler_input, "freeText") or "").strip()
+        lower = spoken.lower()
+        if lower.startswith("add "):
+            title = spoken[4:].strip() or "Untitled task"
+            _api(
+                "/v1/tasks",
+                "POST",
+                {"user_id": FIXED_USER_ID, "description": title, "priority": "normal"},
+            )
+            speech = f"Added task: {title}."
+        elif lower.startswith("complete "):
+            name = spoken[9:].strip()
+            tasks = _api(f"/v1/tasks?user_id={FIXED_USER_ID}&is_completed=false")
+            items = tasks.get("items") if isinstance(tasks, dict) else tasks
+            items = items or []
+            task_id = None
+            for task in items:
+                desc = task.get("description", "").lower()
+                if desc.startswith(name.lower()):
+                    task_id = task.get("_id")
+                    break
+            if not task_id:
+                for task in items:
+                    if name.lower() in task.get("description", "").lower():
+                        task_id = task.get("_id")
+                        break
+            if task_id:
+                _api(
+                    f"/v1/tasks/{urllib.parse.quote(task_id)}",
+                    "PATCH",
+                    {"is_completed": True},
+                )
+                speech = f"Completed task: {name}."
+            else:
+                speech = f"I couldn't find an open task named {name}."
+        else:
+            tasks = _api(f"/v1/tasks?user_id={FIXED_USER_ID}&is_completed=false")
+            items = tasks.get("items") if isinstance(tasks, dict) else tasks
+            names = [task.get("description", "untitled") for task in (items or [])][:5]
+            speech = (
+                "Your top tasks are " + ", ".join(names)
+                if names
+                else "You have no tasks."
+            )
+        return (
+            handler_input.response_builder.speak(speech).set_should_end_session(True).response
+        )
+
+
+class HabitIntentHandler(AbstractRequestHandler):
+    def can_handle(self, handler_input):
+        return is_intent_name("HabitIntent")(handler_input)
+
+    def handle(self, handler_input):
+        spoken = (_slot(handler_input, "freeText") or "").strip()
+        if spoken and not spoken.lower().startswith("check"):
+            _api(
+                "/v1/habit-logs",
+                "POST",
+                {"user_id": FIXED_USER_ID, "name": spoken},
+            )
+            speech = f"Logged habit {spoken}."
+        else:
+            logs = _api(f"/v1/habit-logs?user_id={FIXED_USER_ID}")
+            items = logs.get("items") if isinstance(logs, dict) else logs
+            count = len(items or [])
+            speech = f"Your current habit streak is {count} days."
+        return (
+            handler_input.response_builder.speak(speech).set_should_end_session(True).response
+        )
+
+
+class ScheduleIntentHandler(AbstractRequestHandler):
+    def can_handle(self, handler_input):
+        return is_intent_name("ScheduleIntent")(handler_input)
+
+    def handle(self, handler_input):
+        spoken = (_slot(handler_input, "freeText") or "").strip()
+        if spoken.lower().startswith("add "):
+            summary = spoken[4:].strip()
+            _api(
+                "/v1/schedule",
+                "POST",
+                {"user_id": FIXED_USER_ID, "summary": summary},
+            )
+            speech = "Event added."
+        else:
+            events = _api(f"/v1/schedule?user_id={FIXED_USER_ID}")
+            items = events.get("items") if isinstance(events, dict) else events
+            names = [event.get("summary", "event") for event in (items or [])][:5]
+            speech = (
+                "Today you have " + ", ".join(names)
+                if names
+                else "You have nothing on your schedule today."
+            )
+        return (
+            handler_input.response_builder.speak(speech).set_should_end_session(True).response
+        )
+
+
+class SummaryIntentHandler(AbstractRequestHandler):
+    def can_handle(self, handler_input):
+        return is_intent_name("SummaryIntent")(handler_input)
+
+    def handle(self, handler_input):
+        try:
+            summary = _api(f"/v1/summary?user_id={FIXED_USER_ID}")
+            speech = summary.get("speech", "Here's your daily briefing.")
+        except Exception:
+            tasks = _api(f"/v1/tasks?user_id={FIXED_USER_ID}&is_completed=false")
+            events = _api(f"/v1/schedule?user_id={FIXED_USER_ID}")
+            task_items = tasks.get("items") if isinstance(tasks, dict) else tasks
+            event_items = events.get("items") if isinstance(events, dict) else events
+            speech = (
+                f"You have {len(task_items or [])} open tasks and "
+                f"{len(event_items or [])} events today."
+            )
+        return (
+            handler_input.response_builder.speak(speech).set_should_end_session(True).response
+        )
+
+
+class LaunchHandler(AbstractRequestHandler):
+    def can_handle(self, handler_input):
+        return handler_input.request_envelope.request.object_type == "LaunchRequest"
+
+    def handle(self, handler_input):
+        return (
+            handler_input.response_builder.speak(
+                "Welcome to Daily Routine. Try saying: daily briefing."
+            )
+            .ask("What would you like to do?")
+            .response
+        )
+
+
+sb = SkillBuilder()
+for handler in [
+    LaunchHandler(),
+    TaskIntentHandler(),
+    HabitIntentHandler(),
+    ScheduleIntentHandler(),
+    SummaryIntentHandler(),
+]:
+    sb.add_request_handler(handler)
+
+lambda_handler = sb.lambda_handler()

--- a/alexa/lambda/local_test.py
+++ b/alexa/lambda/local_test.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+import importlib
+import json
+import sys
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterable
+
+FIXTURES_DIR = Path(__file__).resolve().parent / "fixtures"
+
+EXPECTED_PHRASES = {
+    "task_add": "Added task",
+    "task_complete": "Completed task",
+    "task_list": "Your top tasks",
+    "habit_log": "Logged habit",
+    "habit_streak": "habit streak",
+    "sched_list": "Today you have",
+    "sched_add": "Event added",
+    "summary": "daily briefing",
+}
+
+
+def _load_handler():
+    try:
+        module = importlib.import_module("handler")
+    except ModuleNotFoundError as exc:  # pragma: no cover - dependency guard
+        if exc.name == "ask_sdk_core":
+            raise RuntimeError(
+                "ask-sdk-core is required to run the Alexa fixtures. Install it with "
+                "'pip install ask-sdk-core' before executing this script."
+            ) from exc
+        raise
+    return module.lambda_handler, module
+
+
+@contextmanager
+def mock_api(responses: Iterable[tuple[str, str, dict | list | str | None]]):
+    lambda_handler, module = _load_handler()
+    from unittest.mock import patch
+
+    calls = iter(responses)
+
+    def _fake_api(path: str, method: str = "GET", body=None):  # noqa: ANN001
+        try:
+            expected_path, expected_method, payload = next(calls)
+        except StopIteration as exc:  # pragma: no cover - defensive
+            raise AssertionError(f"Unexpected API call: {method} {path}") from exc
+        assert path == expected_path, f"expected path {expected_path}, got {path}"
+        assert (
+            method == expected_method
+        ), f"expected method {expected_method}, got {method}"
+        return payload
+
+    with patch.object(module, "_api", side_effect=_fake_api):
+        yield lambda_handler
+
+
+MOCK_SCENARIOS: dict[str, list[tuple[str, str, dict | list | None]]] = {
+    "task_add": [("/v1/tasks", "POST", {"_id": "task1"})],
+    "task_complete": [
+        (
+            "/v1/tasks?user_id=wendy&is_completed=false",
+            "GET",
+            {
+                "items": [
+                    {"_id": "task1", "description": "buy milk"},
+                    {"_id": "task2", "description": "write report"},
+                ]
+            },
+        ),
+        ("/v1/tasks/task1", "PATCH", {"_id": "task1", "is_completed": True}),
+    ],
+    "task_list": [
+        (
+            "/v1/tasks?user_id=wendy&is_completed=false",
+            "GET",
+            {"items": [{"description": "buy milk"}, {"description": "call mom"}]},
+        )
+    ],
+    "habit_log": [("/v1/habit-logs", "POST", {"_id": "log1"})],
+    "habit_streak": [
+        (
+            "/v1/habit-logs?user_id=wendy",
+            "GET",
+            {"items": [{}, {}, {}]},
+        )
+    ],
+    "sched_list": [
+        (
+            "/v1/schedule?user_id=wendy",
+            "GET",
+            {
+                "items": [
+                    {"summary": "dentist"},
+                    {"summary": "team sync"},
+                ]
+            },
+        )
+    ],
+    "sched_add": [("/v1/schedule", "POST", {"_id": "event1"})],
+    "summary": [
+        (
+            "/v1/summary?user_id=wendy",
+            "GET",
+            {
+                "speech": "Here's your daily briefing. You have 2 tasks and 1 event.",
+            },
+        )
+    ],
+}
+
+
+def _extract_speech(response: dict) -> str:
+    output = response.get("response", {}).get("outputSpeech", {})
+    if "text" in output:
+        return output["text"]
+    if "ssml" in output:
+        speech = output["ssml"]
+        return speech.replace("<speak>", "").replace("</speak>", "")
+    return ""
+
+
+def run_fixture(name: str) -> str:
+    fixture_path = FIXTURES_DIR / f"{name}.json"
+    if not fixture_path.exists():
+        raise FileNotFoundError(f"Unknown fixture {name}")
+    event = json.loads(fixture_path.read_text("utf-8"))
+    responses = MOCK_SCENARIOS.get(name, [])
+    with mock_api(responses) as handler:
+        result = handler(event, None)
+    speech = _extract_speech(result)
+    expected = EXPECTED_PHRASES.get(name)
+    if expected and expected.lower() not in speech.lower():
+        raise AssertionError(f"Expected phrase '{expected}' in speech '{speech}'")
+    return speech
+
+
+def main(argv: list[str]) -> None:
+    if len(argv) > 1:
+        name = argv[1].replace(".json", "")
+        speech = run_fixture(name)
+        print(f"{name}: {speech}")
+    else:
+        for name in sorted(MOCK_SCENARIOS):
+            speech = run_fixture(name)
+            print(f"{name}: {speech}")
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    main(sys.argv)

--- a/api/app/schemas/schedule_event.py
+++ b/api/app/schemas/schedule_event.py
@@ -12,6 +12,8 @@ class ScheduleEvent(MongoModel):
     start_time: datetime
     end_time: datetime
     description: Optional[str] = None
+    location: Optional[str] = None
+    summary: Optional[str] = None
 
     @classmethod
     def from_mongo(cls, doc: dict) -> "ScheduleEvent":
@@ -38,3 +40,5 @@ class ScheduleEventCreate(MongoModel):
     start_time: datetime
     end_time: datetime
     description: Optional[str] = None
+    location: Optional[str] = None
+    summary: Optional[str] = None

--- a/api/app/utils/broadcast.py
+++ b/api/app/utils/broadcast.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+async def broadcast_event(event_type: str, payload: dict[str, Any] | None = None) -> None:
+    """Placeholder broadcast hook for websocket updates."""
+
+    logger.debug("broadcast_event called", extra={"event_type": event_type, "payload": payload})
+
+
+__all__ = ["broadcast_event"]

--- a/api/main.py
+++ b/api/main.py
@@ -11,7 +11,9 @@ if __package__:
     from .habit_logs import router as habit_logs_router
     from .habits import router as habits_router
     from .health import router as health_router
+    from .schedule import alias_router as schedule_alias_router
     from .schedule import router as schedule_router
+    from .summary import router as summary_router
     from .tasks import router as tasks_router
     from .users import router as users_router
 else:  # pragma: no cover - handles ``uvicorn main:app`` when cwd==api/
@@ -22,7 +24,9 @@ else:  # pragma: no cover - handles ``uvicorn main:app`` when cwd==api/
     from habit_logs import router as habit_logs_router
     from habits import router as habits_router
     from health import router as health_router
+    from schedule import alias_router as schedule_alias_router
     from schedule import router as schedule_router
+    from summary import router as summary_router
     from tasks import router as tasks_router
     from users import router as users_router
 
@@ -51,6 +55,8 @@ def make_app() -> FastAPI:
         habit_logs_router,
         habit_logs_alias_router,
         schedule_router,
+        schedule_alias_router,
+        summary_router,
         health_router,
     ]
 

--- a/api/schedule.py
+++ b/api/schedule.py
@@ -1,27 +1,46 @@
 from __future__ import annotations
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Optional
 
 from bson import ObjectId
 from fastapi import APIRouter, HTTPException, Query
+from pydantic import BaseModel, Field
 
 if __package__:
     from .app.db import get_db
     from .app.schemas.common import ListResponse
     from .app.schemas.schedule_event import ScheduleEvent, ScheduleEventCreate
+    from .app.utils.broadcast import broadcast_event
+    from .app.utils.object_ids import resolve_object_id
 else:  # pragma: no cover - handles ``uvicorn main:app`` when cwd==api/
     from app.db import get_db
     from app.schemas.common import ListResponse
     from app.schemas.schedule_event import ScheduleEvent, ScheduleEventCreate
-
-if __package__:
-    from .app.utils.object_ids import resolve_object_id
-else:  # pragma: no cover
+    from app.utils.broadcast import broadcast_event
     from app.utils.object_ids import resolve_object_id
 
 
 router = APIRouter(prefix="/schedule-events", tags=["schedule"])
+alias_router = APIRouter(prefix="/schedule", tags=["schedule"])
+
+
+def _normalize_datetime(value: datetime) -> datetime:
+    if value.tzinfo:
+        return value.astimezone(timezone.utc).replace(tzinfo=None)
+    return value
+
+
+class CreateScheduleRequest(BaseModel):
+    user_id: str = Field(..., description="User identifier or alias")
+    summary: str = Field(..., min_length=1, description="Event summary")
+    start: Optional[datetime] = Field(
+        None, description="ISO8601 start time (defaults to today at 09:00)"
+    )
+    end: Optional[datetime] = Field(
+        None, description="ISO8601 end time (defaults to start + 1 hour)"
+    )
+    location: Optional[str] = Field(None, description="Event location")
 
 
 def _parse_object_id(value: str, field: str) -> ObjectId:
@@ -41,12 +60,50 @@ async def create_event(payload: ScheduleEventCreate) -> ScheduleEvent:
     start_time = doc.get("start_time") or now
     doc["start_time"] = start_time
     doc["end_time"] = doc.get("end_time") or (start_time + timedelta(hours=1))
+    doc.setdefault("summary", doc.get("title"))
     doc.update({"created_at": now, "updated_at": now})
 
     res = await events.insert_one(doc)
     saved = await events.find_one({"_id": res.inserted_id})
     assert saved is not None
-    return ScheduleEvent.from_mongo(saved)
+    event = ScheduleEvent.from_mongo(saved)
+    await broadcast_event("schedule_created", {"event_id": str(event.id)})
+    return event
+
+
+@alias_router.post("", response_model=ScheduleEvent, status_code=201)
+async def create_schedule_item(payload: CreateScheduleRequest) -> ScheduleEvent:
+    db = get_db()
+    events = db.schedule_events
+
+    now = datetime.utcnow()
+    start_time = _normalize_datetime(payload.start) if payload.start else None
+    if start_time is None:
+        today = now.astimezone(timezone.utc) if now.tzinfo else now
+        start_time = today.replace(hour=9, minute=0, second=0, microsecond=0)
+    end_time = _normalize_datetime(payload.end) if payload.end else start_time + timedelta(hours=1)
+
+    summary = payload.summary.strip()
+    if not summary:
+        raise HTTPException(status_code=400, detail="Summary is required")
+
+    doc = {
+        "user_id": _parse_object_id(payload.user_id, "user_id"),
+        "title": summary,
+        "summary": summary,
+        "location": payload.location,
+        "start_time": start_time,
+        "end_time": end_time,
+        "created_at": now,
+        "updated_at": now,
+    }
+
+    res = await events.insert_one(doc)
+    saved = await events.find_one({"_id": res.inserted_id})
+    assert saved is not None
+    event = ScheduleEvent.from_mongo(saved)
+    await broadcast_event("schedule_created", {"event_id": str(event.id)})
+    return event
 
 
 @router.get("", response_model=ListResponse[ScheduleEvent])
@@ -74,6 +131,28 @@ async def list_events(
     return ListResponse[ScheduleEvent](items=items, total=len(items))
 
 
+@alias_router.get("", response_model=ListResponse[ScheduleEvent])
+async def list_schedule(
+    user_id: str = Query(..., description="User ID"),
+) -> ListResponse[ScheduleEvent]:
+    db = get_db()
+    events = db.schedule_events
+
+    start_of_day = datetime.utcnow().replace(hour=0, minute=0, second=0, microsecond=0)
+    end_of_day = start_of_day + timedelta(days=1)
+
+    query: dict[str, object] = {
+        "user_id": _parse_object_id(user_id, "user_id"),
+        "start_time": {"$gte": start_of_day, "$lt": end_of_day},
+    }
+
+    cursor = events.find(query).sort("start_time", 1)
+    items: list[ScheduleEvent] = []
+    async for doc in cursor:
+        items.append(ScheduleEvent.from_mongo(doc))
+    return ListResponse[ScheduleEvent](items=items, total=len(items))
+
+
 @router.delete("/{event_id}", status_code=204)
 async def delete_event(event_id: str) -> None:
     db = get_db()
@@ -83,3 +162,6 @@ async def delete_event(event_id: str) -> None:
     res = await events.delete_one({"_id": oid})
     if res.deleted_count == 0:
         raise HTTPException(status_code=404, detail="Event not found")
+
+
+__all__ = ["router", "alias_router"]

--- a/api/summary.py
+++ b/api/summary.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+from datetime import datetime, timedelta
+
+from fastapi import APIRouter, HTTPException, Query
+
+if __package__:
+    from .app.db import get_db
+    from .app.utils.object_ids import resolve_object_id
+else:  # pragma: no cover - handles ``uvicorn main:app`` when cwd==api/
+    from app.db import get_db
+    from app.utils.object_ids import resolve_object_id
+
+router = APIRouter(prefix="/summary", tags=["summary"])
+
+
+def _parse_object_id(value: str, field: str):
+    try:
+        return resolve_object_id(value, field)
+    except ValueError as exc:  # pragma: no cover
+        raise HTTPException(status_code=400, detail=f"Invalid {field}") from exc
+
+
+@router.get("")
+async def summary(user_id: str = Query(..., description="User ID")) -> dict[str, object]:
+    db = get_db()
+    user_oid = _parse_object_id(user_id, "user_id")
+
+    tasks_cursor = (
+        db.tasks.find({"user_id": user_oid, "is_completed": False}).sort("created_at", 1).limit(5)
+    )
+    tasks: list[dict] = []
+    async for doc in tasks_cursor:
+        tasks.append(doc)
+
+    now = datetime.utcnow()
+    start_of_day = now.replace(hour=0, minute=0, second=0, microsecond=0)
+    end_of_day = start_of_day + timedelta(days=1)
+
+    events_cursor = (
+        db.schedule_events.find(
+            {"user_id": user_oid, "start_time": {"$gte": start_of_day, "$lt": end_of_day}}
+        )
+        .sort("start_time", 1)
+        .limit(5)
+    )
+    events: list[dict] = []
+    async for doc in events_cursor:
+        events.append(doc)
+
+    logs_count = await db.habit_logs.count_documents(
+        {"user_id": user_oid, "date": {"$gte": start_of_day, "$lt": end_of_day}}
+    )
+
+    task_count = len(tasks)
+    event_count = len(events)
+
+    task_names = [doc.get("description") or "a task" for doc in tasks[:3]]
+    event_names = [
+        doc.get("summary") or doc.get("title") or doc.get("description") or "an event"
+        for doc in events[:3]
+    ]
+
+    speech_parts: list[str] = []
+    if task_count:
+        detail = f", including {', '.join(task_names)}" if task_names else ""
+        speech_parts.append(f"You have {task_count} open tasks{detail}")
+    else:
+        speech_parts.append("You have no open tasks")
+
+    if event_count:
+        speech_parts.append("Today's schedule includes " + ", ".join(event_names))
+    else:
+        speech_parts.append("Your schedule is clear")
+
+    if logs_count:
+        speech_parts.append(f"You've logged {logs_count} habits today")
+    else:
+        speech_parts.append("You have not logged any habits today")
+
+    speech = ". ".join(speech_parts) + "."
+
+    return {
+        "speech": speech,
+        "tasks_count": task_count,
+        "events_count": event_count,
+        "habits_logged_today": logs_count,
+    }
+
+
+__all__ = ["router"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from typing import Iterator
+
+import pytest
+
+from tests.fakes import FakeDB
+
+import api.schedule as schedule_module
+import api.summary as summary_module
+import api.tasks as tasks_module
+
+
+@pytest.fixture
+def fake_db(monkeypatch: pytest.MonkeyPatch) -> Iterator[FakeDB]:
+    db = FakeDB()
+    for module in (tasks_module, schedule_module, summary_module):
+        monkeypatch.setattr(module, "get_db", lambda db=db: db)
+    yield db
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Dict, Iterable, Iterator, List, Optional
+
+from bson import ObjectId
+
+
+class FakeCursor:
+    def __init__(self, docs: Iterable[dict]) -> None:
+        self._base_docs = list(docs)
+        self._sort_key: Optional[str] = None
+        self._sort_direction: int = 1
+        self._limit: Optional[int] = None
+        self._iter: Optional[Iterator[dict]] = None
+
+    def sort(self, key: str, direction: int) -> "FakeCursor":
+        self._sort_key = key
+        self._sort_direction = direction
+        return self
+
+    def limit(self, value: int) -> "FakeCursor":
+        self._limit = value
+        return self
+
+    def _prepare(self) -> List[dict]:
+        docs = list(self._base_docs)
+        if self._sort_key is not None:
+            reverse = self._sort_direction < 0
+            docs.sort(key=lambda doc: doc.get(self._sort_key), reverse=reverse)
+        if self._limit is not None:
+            docs = docs[: self._limit]
+        return [dict(doc) for doc in docs]
+
+    def __aiter__(self) -> "FakeCursor":
+        self._iter = iter(self._prepare())
+        return self
+
+    async def __anext__(self) -> dict:
+        assert self._iter is not None
+        try:
+            return next(self._iter)
+        except StopIteration as exc:  # pragma: no cover - defensive guard
+            raise StopAsyncIteration from exc
+
+
+@dataclass
+class FakeInsertOneResult:
+    inserted_id: ObjectId
+
+
+@dataclass
+class FakeUpdateResult:
+    matched_count: int
+    modified_count: int
+
+
+@dataclass
+class FakeDeleteResult:
+    deleted_count: int
+
+
+class FakeCollection:
+    def __init__(self, docs: Optional[List[dict]] = None) -> None:
+        self.docs: List[dict] = docs or []
+
+    async def insert_one(self, doc: dict) -> FakeInsertOneResult:
+        payload = dict(doc)
+        payload.setdefault("_id", ObjectId())
+        self.docs.append(payload)
+        return FakeInsertOneResult(inserted_id=payload["_id"])
+
+    async def find_one(self, query: Dict[str, Any]) -> Optional[dict]:
+        for doc in self.docs:
+            if self._matches(doc, query):
+                return dict(doc)
+        return None
+
+    def find(self, query: Dict[str, Any]) -> FakeCursor:
+        filtered = [doc for doc in self.docs if self._matches(doc, query)]
+        return FakeCursor(filtered)
+
+    async def update_one(self, query: Dict[str, Any], update: Dict[str, Any]) -> FakeUpdateResult:
+        matched = 0
+        for doc in self.docs:
+            if self._matches(doc, query):
+                matched += 1
+                for op, changes in update.items():
+                    if op == "$set":
+                        doc.update(changes)
+        return FakeUpdateResult(matched_count=matched, modified_count=matched)
+
+    async def delete_one(self, query: Dict[str, Any]) -> FakeDeleteResult:
+        for idx, doc in enumerate(self.docs):
+            if self._matches(doc, query):
+                del self.docs[idx]
+                return FakeDeleteResult(deleted_count=1)
+        return FakeDeleteResult(deleted_count=0)
+
+    async def count_documents(self, query: Dict[str, Any]) -> int:
+        return sum(1 for doc in self.docs if self._matches(doc, query))
+
+    def _matches(self, doc: dict, query: Dict[str, Any]) -> bool:
+        for key, expected in query.items():
+            value = doc.get(key)
+            if isinstance(expected, dict):
+                for op, operand in expected.items():
+                    if op == "$gte" and not (value >= operand):
+                        return False
+                    if op == "$gt" and not (value > operand):
+                        return False
+                    if op == "$lte" and not (value <= operand):
+                        return False
+                    if op == "$lt" and not (value < operand):
+                        return False
+            else:
+                if value != expected:
+                    return False
+        return True
+
+
+class FakeDB:
+    def __init__(self) -> None:
+        self.tasks = FakeCollection([])
+        self.schedule_events = FakeCollection([])
+        self.habit_logs = FakeCollection([])
+
+
+__all__ = ["FakeCollection", "FakeCursor", "FakeDB"]

--- a/tests/test_schedule_post_get.py
+++ b/tests/test_schedule_post_get.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+import pytest
+from bson import ObjectId
+
+import api.schedule as schedule_module
+
+
+@pytest.mark.anyio("asyncio")
+async def test_create_schedule_item_defaults_and_list(fake_db):
+    user_id = ObjectId()
+
+    payload = schedule_module.CreateScheduleRequest(
+        user_id=str(user_id),
+        summary="Dentist appointment",
+        location="Downtown Clinic",
+    )
+
+    event = await schedule_module.create_schedule_item(payload)
+    assert event.summary == "Dentist appointment"
+    assert event.location == "Downtown Clinic"
+    assert event.start_time.hour == 9
+
+    listing = await schedule_module.list_schedule(user_id=str(user_id))
+    assert listing.total == 1
+    assert listing.items[0].summary == "Dentist appointment"

--- a/tests/test_summary_endpoint.py
+++ b/tests/test_summary_endpoint.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+import pytest
+from bson import ObjectId
+
+import api.summary as summary_module
+
+
+@pytest.mark.anyio("asyncio")
+async def test_summary_returns_counts(fake_db):
+    user_id = ObjectId()
+    now = datetime.utcnow()
+
+    fake_db.tasks.docs = [
+        {
+            "_id": ObjectId(),
+            "user_id": user_id,
+            "description": "Buy milk",
+            "is_completed": False,
+            "created_at": now,
+            "updated_at": now,
+        },
+        {
+            "_id": ObjectId(),
+            "user_id": user_id,
+            "description": "Write report",
+            "is_completed": False,
+            "created_at": now,
+            "updated_at": now,
+        },
+    ]
+
+    fake_db.schedule_events.docs = [
+        {
+            "_id": ObjectId(),
+            "user_id": user_id,
+            "title": "Team sync",
+            "summary": "Team sync",
+            "start_time": now.replace(hour=10, minute=0, second=0, microsecond=0),
+            "end_time": now.replace(hour=11, minute=0, second=0, microsecond=0),
+        }
+    ]
+
+    fake_db.habit_logs.docs = [
+        {
+            "_id": ObjectId(),
+            "user_id": user_id,
+            "date": now,
+        },
+        {
+            "_id": ObjectId(),
+            "user_id": user_id,
+            "date": now - timedelta(hours=1),
+        },
+    ]
+
+    result = await summary_module.summary(user_id=str(user_id))
+    assert result["tasks_count"] == 2
+    assert result["events_count"] == 1
+    assert result["habits_logged_today"] == 2
+    assert "daily" not in result["speech"].lower()
+    assert "You have 2 open tasks" in result["speech"]

--- a/tests/test_tasks_complete_by_name.py
+++ b/tests/test_tasks_complete_by_name.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+import pytest
+from bson import ObjectId
+from fastapi import HTTPException
+
+import api.tasks as tasks_module
+
+
+@pytest.mark.anyio("asyncio")
+async def test_complete_by_name_updates_task(fake_db):
+    user_id = ObjectId()
+    now = datetime.utcnow()
+    fake_db.tasks.docs = [
+        {
+            "_id": ObjectId(),
+            "user_id": user_id,
+            "description": "buy milk",
+            "is_completed": False,
+            "created_at": now - timedelta(minutes=5),
+            "updated_at": now - timedelta(minutes=5),
+        },
+        {
+            "_id": ObjectId(),
+            "user_id": user_id,
+            "description": "write report",
+            "is_completed": False,
+            "created_at": now - timedelta(minutes=1),
+            "updated_at": now - timedelta(minutes=1),
+        },
+    ]
+
+    payload = tasks_module.CompleteByNameRequest(user_id=str(user_id), name="buy")
+    result = await tasks_module.complete_by_name(payload)
+
+    assert result.is_completed is True
+    assert fake_db.tasks.docs[0]["is_completed"] is True
+
+
+@pytest.mark.anyio("asyncio")
+async def test_complete_by_name_missing_task(fake_db):
+    user_id = ObjectId()
+    fake_db.tasks.docs = [
+        {
+            "_id": ObjectId(),
+            "user_id": user_id,
+            "description": "call mom",
+            "is_completed": False,
+            "created_at": datetime.utcnow(),
+            "updated_at": datetime.utcnow(),
+        }
+    ]
+
+    payload = tasks_module.CompleteByNameRequest(user_id=str(user_id), name="buy")
+    with pytest.raises(HTTPException) as exc:
+        await tasks_module.complete_by_name(payload)
+    assert exc.value.status_code == 404


### PR DESCRIPTION
## Summary
- add Alexa interaction model, Lambda handler, and fixtures with a local runner for deterministic testing
- extend the FastAPI backend with schedule aliases, task completion by name, a summary endpoint, and a broadcast utility
- update documentation and add pytest-based unit tests covering the new backend flows

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ddad6ad1dc83269e6c35237d3f2401