### PR TITLE
Add Gemini insights endpoints with fact builders and caching

### DIFF
--- a/api/app/config.py
+++ b/api/app/config.py
@@ -45,6 +45,9 @@ API_CORS_ORIGINS: list[str] = [
     if o.strip()
 ]
 
+GEMINI_API_KEY: str | None = os.getenv("GEMINI_API_KEY")
+GEMINI_MODEL: str = os.getenv("GEMINI_MODEL", "gemini-1.5-flash")
+
 
 def _parse_alias_map(raw: str) -> Dict[str, str]:
     mapping: Dict[str, str] = {}

--- a/api/app/indexes.py
+++ b/api/app/indexes.py
@@ -34,6 +34,10 @@ async def ensure_indexes() -> None:
 
         # schedule_events: list by user + start time
         await db.schedule_events.create_index([("user_id", ASCENDING), ("start_time", ASCENDING)])
+
+        # insights cache: expire old entries and allow hash lookups
+        await db.insights.create_index([("ts", ASCENDING)], expireAfterSeconds=60 * 60 * 24 * 90)
+        await db.insights.create_index([("facts_hash", ASCENDING)])
     except _CONNECTION_ERRORS as exc:
         _logger.warning("Skipping MongoDB index creation because the database is unreachable: %s", exc)
     except PyMongoError:

--- a/api/app/services/__init__.py
+++ b/api/app/services/__init__.py
@@ -1,0 +1,3 @@
+"""Service helpers for AI-generated insights."""
+
+__all__ = []

--- a/api/app/services/gemini_client.py
+++ b/api/app/services/gemini_client.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from dataclasses import dataclass
+from typing import Any, Dict, Literal, Mapping
+
+import google.generativeai as genai
+
+from ..config import GEMINI_API_KEY, GEMINI_MODEL
+
+logger = logging.getLogger(__name__)
+
+
+class GeminiConfigurationError(RuntimeError):
+    """Raised when the Gemini client is not configured correctly."""
+
+
+class GeminiGenerationError(RuntimeError):
+    """Raised when the Gemini API fails to generate a response."""
+
+
+_SYSTEM_PROMPT = """You are an assistant generating productivity insights from structured FACTS.\nRules:\n- Only use provided FACTS. If data is missing, say \"unknown\" instead of guessing.\n- Keep outputs concise and actionable for a dashboard.\n- Prefer clear bullet points. Avoid flowery language.\n- Never invent tasks, habits, or numbers not present or derivable from FACTS."""
+
+_DAILY_TASK = """Create a daily briefing with:\n1) Key changes vs. yesterday (tasks/habits/events)\n2) Today’s top priorities (<=3)\n3) Risk or blocker (if any)\n4) One concrete suggestion (<=1 sentence)\nReturn JSON: { \"speech\": string, \"bullets\": string[] }"""
+
+_MONTHLY_TASK = """Create a monthly summary with:\n- Trends (task completions, habit frequency)\n- Best/worst weekdays and time windows\n- Missed/overdue patterns\n- Recommendations (max 3)\nReturn JSON: { \"summary\": string, \"bullets\": string[], \"recommendations\": string[] }"""
+
+
+@dataclass(slots=True)
+class _GeminiSession:
+    model_name: str
+    api_key: str
+    _model: genai.GenerativeModel | None = None
+
+    def get_model(self) -> genai.GenerativeModel:
+        if not self.api_key:
+            raise GeminiConfigurationError("GEMINI_API_KEY is not configured")
+
+        if self._model is None:
+            genai.configure(api_key=self.api_key)
+            self._model = genai.GenerativeModel(self.model_name)
+        return self._model
+
+
+_session: _GeminiSession | None = None
+
+
+def _get_session() -> _GeminiSession:
+    global _session
+    if _session is None:
+        _session = _GeminiSession(model_name=GEMINI_MODEL, api_key=GEMINI_API_KEY or "")
+    return _session
+
+
+def _task_for_mode(mode: Literal["daily", "monthly"]) -> str:
+    if mode == "daily":
+        return _DAILY_TASK
+    if mode == "monthly":
+        return _MONTHLY_TASK
+    raise ValueError(f"Unsupported insight mode: {mode}")
+
+
+def _serialize_facts(facts: Mapping[str, Any]) -> str:
+    return json.dumps(facts, separators=(",", ":"), ensure_ascii=False, sort_keys=True)
+
+
+def _extract_text(response: Any) -> str:
+    text = getattr(response, "text", None)
+    if text:
+        return text
+
+    candidates = getattr(response, "candidates", []) or []
+    for candidate in candidates:
+        content = getattr(candidate, "content", None)
+        parts = getattr(content, "parts", []) if content else []
+        for part in parts:
+            part_text = getattr(part, "text", None)
+            if part_text:
+                return part_text
+    raise GeminiGenerationError("Gemini response did not contain text content")
+
+
+async def generate_insight(facts: Mapping[str, Any], mode: Literal["daily", "monthly"]) -> Dict[str, Any]:
+    session = _get_session()
+    try:
+        model = session.get_model()
+    except GeminiConfigurationError:
+        raise
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.exception("Failed to initialise Gemini model")
+        raise GeminiConfigurationError("Unable to initialise Gemini model") from exc
+
+    payload = [
+        {"role": "system", "parts": [{"text": _SYSTEM_PROMPT}]},
+        {
+            "role": "user",
+            "parts": [
+                {"text": _task_for_mode(mode)},
+                {"text": "FACTS:"},
+                {"text": _serialize_facts(facts)},
+            ],
+        },
+    ]
+
+    def _invoke() -> Dict[str, Any]:
+        try:
+            response = model.generate_content(
+                payload,
+                generation_config={"response_mime_type": "application/json"},
+            )
+        except Exception as exc:  # pragma: no cover - network failures
+            logger.exception("Gemini generation failed")
+            raise GeminiGenerationError("Gemini API call failed") from exc
+
+        try:
+            text = _extract_text(response)
+        except GeminiGenerationError:
+            raise
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.exception("Failed to extract Gemini response text")
+            raise GeminiGenerationError("Unexpected Gemini response format") from exc
+
+        if not text.strip():
+            raise GeminiGenerationError("Gemini returned an empty response")
+
+        try:
+            return json.loads(text)
+        except json.JSONDecodeError:
+            logger.warning("Gemini response was not valid JSON; returning raw text")
+            return {"speech": text.strip(), "bullets": []}
+
+    return await asyncio.to_thread(_invoke)
+
+
+__all__ = [
+    "GeminiConfigurationError",
+    "GeminiGenerationError",
+    "generate_insight",
+]

--- a/api/app/services/insight_facts.py
+++ b/api/app/services/insight_facts.py
@@ -1,0 +1,293 @@
+from __future__ import annotations
+
+from collections import Counter
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, List
+
+from bson import ObjectId
+from motor.motor_asyncio import AsyncIOMotorDatabase
+
+
+def _normalize_datetime(value: datetime | None) -> datetime | None:
+    if value is None:
+        return None
+    if value.tzinfo is not None:
+        return value.astimezone(timezone.utc).replace(tzinfo=None)
+    return value
+
+
+def _start_end_for_day(moment: datetime) -> tuple[datetime, datetime]:
+    normalized = _normalize_datetime(moment) or datetime.utcnow()
+    start = normalized.replace(hour=0, minute=0, second=0, microsecond=0)
+    return start, start + timedelta(days=1)
+
+
+def _start_end_for_month(moment: datetime) -> tuple[datetime, datetime]:
+    normalized = _normalize_datetime(moment) or datetime.utcnow()
+    start = normalized.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+    if start.month == 12:
+        end = start.replace(year=start.year + 1, month=1)
+    else:
+        end = start.replace(month=start.month + 1)
+    return start, end
+
+
+def _iso(dt: datetime | None) -> str | None:
+    if not isinstance(dt, datetime):
+        return None
+    value = dt.isoformat()
+    if dt.tzinfo is None:
+        return value + "Z"
+    return value
+
+
+async def build_daily_facts(
+    db: AsyncIOMotorDatabase,
+    user_id: ObjectId,
+    reference: datetime,
+) -> Dict[str, Any]:
+    start, end = _start_end_for_day(reference)
+    y_start, y_end = _start_end_for_day(reference - timedelta(days=1))
+    now = _normalize_datetime(reference) or datetime.utcnow()
+
+    tasks = db.tasks
+    habits = db.habit_logs
+    habit_defs = db.habits
+    events = db.schedule_events
+
+    open_count = await tasks.count_documents({"user_id": user_id, "is_completed": False})
+
+    open_cursor = (
+        tasks.find(
+            {"user_id": user_id, "is_completed": False},
+            {"description": 1, "priority": 1, "due_date": 1, "created_at": 1},
+        )
+        .sort([("priority", 1), ("due_date", 1), ("created_at", 1)])
+        .limit(5)
+    )
+    top_open: List[Dict[str, Any]] = []
+    async for doc in open_cursor:
+        top_open.append(
+            {
+                "description": doc.get("description"),
+                "priority": doc.get("priority"),
+                "due_date": _iso(doc.get("due_date")),
+            }
+        )
+
+    completed_cursor = tasks.find(
+        {
+            "user_id": user_id,
+            "is_completed": True,
+            "updated_at": {"$gte": start, "$lt": end},
+        },
+        {"created_at": 1, "updated_at": 1},
+    )
+    completed_today_docs = await completed_cursor.to_list(length=250)
+    completed_today = len(completed_today_docs)
+
+    durations: List[float] = []
+    for doc in completed_today_docs:
+        created = doc.get("created_at")
+        updated = doc.get("updated_at")
+        if isinstance(created, datetime) and isinstance(updated, datetime) and updated >= created:
+            durations.append((updated - created).total_seconds() / 3600)
+    avg_completion_time_hours = round(sum(durations) / len(durations), 2) if durations else None
+
+    completed_yesterday = await tasks.count_documents(
+        {
+            "user_id": user_id,
+            "is_completed": True,
+            "updated_at": {"$gte": y_start, "$lt": y_end},
+        }
+    )
+
+    created_today = await tasks.count_documents(
+        {
+            "user_id": user_id,
+            "created_at": {"$gte": start, "$lt": end},
+        }
+    )
+
+    overdue_count = await tasks.count_documents(
+        {
+            "user_id": user_id,
+            "is_completed": False,
+            "due_date": {"$lt": start},
+        }
+    )
+
+    logs_cursor = habits.find(
+        {"user_id": user_id, "date": {"$gte": start, "$lt": end}},
+        {"habit_id": 1, "status": 1},
+    )
+    logs_today = await logs_cursor.to_list(length=200)
+    habit_ids = {doc.get("habit_id") for doc in logs_today if isinstance(doc.get("habit_id"), ObjectId)}
+    habit_map: Dict[ObjectId, str] = {}
+    if habit_ids:
+        habit_cursor = habit_defs.find({"_id": {"$in": list(habit_ids)}}, {"name": 1})
+        async for habit in habit_cursor:
+            if isinstance(habit.get("_id"), ObjectId):
+                habit_map[habit["_id"]] = habit.get("name", "")
+
+    habit_examples = []
+    for doc in logs_today:
+        habit_id = doc.get("habit_id")
+        name = habit_map.get(habit_id)
+        if name and name not in habit_examples:
+            habit_examples.append(name)
+        if len(habit_examples) >= 5:
+            break
+
+    status_counter = Counter(doc.get("status") for doc in logs_today if isinstance(doc.get("status"), str))
+
+    events_today_count = await events.count_documents(
+        {"user_id": user_id, "start_time": {"$gte": start, "$lt": end}}
+    )
+
+    upcoming_cursor = (
+        events.find(
+            {"user_id": user_id, "start_time": {"$gte": start, "$lt": end}},
+            {"summary": 1, "title": 1, "start_time": 1},
+        )
+        .sort("start_time", 1)
+        .limit(5)
+    )
+    today_events: List[Dict[str, Any]] = []
+    async for doc in upcoming_cursor:
+        summary = doc.get("summary") or doc.get("title")
+        today_events.append({"summary": summary, "start_time": _iso(doc.get("start_time"))})
+
+    next_event_doc = await events.find_one(
+        {"user_id": user_id, "start_time": {"$gte": now}},
+        sort=[("start_time", 1)],
+        projection={"summary": 1, "title": 1, "start_time": 1},
+    )
+
+    next_event: Dict[str, Any] | None = None
+    if next_event_doc:
+        summary = next_event_doc.get("summary") or next_event_doc.get("title")
+        next_event = {"summary": summary, "start_time": _iso(next_event_doc.get("start_time"))}
+
+    return {
+        "period": "daily",
+        "generated_at": _iso(now),
+        "day": start.date().isoformat(),
+        "tasks": {
+            "open_count": open_count,
+            "completed_today": completed_today,
+            "completed_yesterday": completed_yesterday,
+            "created_today": created_today,
+            "overdue_count": overdue_count,
+            "avg_completion_time_hours": avg_completion_time_hours,
+            "top_open": top_open,
+        },
+        "habits": {
+            "logged_today": len(logs_today),
+            "status_breakdown": dict(status_counter),
+            "examples": habit_examples,
+        },
+        "schedule": {
+            "events_today": events_today_count,
+            "next_event": next_event,
+            "today_events": today_events,
+        },
+    }
+
+
+async def build_monthly_facts(
+    db: AsyncIOMotorDatabase,
+    user_id: ObjectId,
+    reference: datetime,
+) -> Dict[str, Any]:
+    start, end = _start_end_for_month(reference)
+
+    tasks = db.tasks
+    habits = db.habit_logs
+    habit_defs = db.habits
+    events = db.schedule_events
+
+    created_count = await tasks.count_documents(
+        {"user_id": user_id, "created_at": {"$gte": start, "$lt": end}}
+    )
+
+    completed_cursor = tasks.find(
+        {
+            "user_id": user_id,
+            "is_completed": True,
+            "updated_at": {"$gte": start, "$lt": end},
+        },
+        {"updated_at": 1},
+    )
+    completed_docs = await completed_cursor.to_list(length=1000)
+    completed_count = len(completed_docs)
+
+    weekday_counter = Counter()
+    for doc in completed_docs:
+        updated = doc.get("updated_at")
+        if isinstance(updated, datetime):
+            weekday_counter[updated.weekday()] += 1
+
+    open_count = await tasks.count_documents({"user_id": user_id, "is_completed": False})
+
+    habit_logs_cursor = habits.find(
+        {"user_id": user_id, "date": {"$gte": start, "$lt": end}},
+        {"habit_id": 1, "status": 1},
+    )
+    habit_log_docs = await habit_logs_cursor.to_list(length=2000)
+    habit_ids = {doc.get("habit_id") for doc in habit_log_docs if isinstance(doc.get("habit_id"), ObjectId)}
+
+    habit_map: Dict[ObjectId, str] = {}
+    if habit_ids:
+        habit_cursor = habit_defs.find({"_id": {"$in": list(habit_ids)}}, {"name": 1})
+        async for doc in habit_cursor:
+            if isinstance(doc.get("_id"), ObjectId):
+                habit_map[doc["_id"]] = doc.get("name", "")
+
+    habit_counter = Counter()
+    status_counter = Counter()
+    for doc in habit_log_docs:
+        habit_id = doc.get("habit_id")
+        status = doc.get("status")
+        if isinstance(status, str):
+            status_counter[status] += 1
+        name = habit_map.get(habit_id)
+        if name:
+            habit_counter[name] += 1
+
+    schedule_cursor = events.find(
+        {"user_id": user_id, "start_time": {"$gte": start, "$lt": end}},
+        {"start_time": 1},
+    )
+    schedule_docs = await schedule_cursor.to_list(length=1000)
+    schedule_weekdays = Counter()
+    schedule_hours = Counter()
+    for doc in schedule_docs:
+        start_time = doc.get("start_time")
+        if isinstance(start_time, datetime):
+            schedule_weekdays[start_time.weekday()] += 1
+            schedule_hours[start_time.hour] += 1
+
+    return {
+        "period": "monthly",
+        "month": start.strftime("%Y-%m"),
+        "tasks": {
+            "created": created_count,
+            "completed": completed_count,
+            "open": open_count,
+            "completions_by_weekday": dict(weekday_counter),
+        },
+        "habits": {
+            "total_logs": len(habit_log_docs),
+            "status_breakdown": dict(status_counter),
+            "top_habits": habit_counter.most_common(5),
+        },
+        "schedule": {
+            "events": len(schedule_docs),
+            "events_by_weekday": dict(schedule_weekdays),
+            "events_by_hour": dict(schedule_hours),
+        },
+    }
+
+
+__all__ = ["build_daily_facts", "build_monthly_facts"]

--- a/api/insights.py
+++ b/api/insights.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime
+from typing import Any, Dict
+
+from fastapi import APIRouter, HTTPException, Query
+
+if __package__:
+    from .app.db import get_db
+    from .app.services.gemini_client import (
+        GeminiConfigurationError,
+        GeminiGenerationError,
+        generate_insight,
+    )
+    from .app.services.insight_facts import build_daily_facts, build_monthly_facts
+    from .app.utils.broadcast import broadcast_event
+    from .app.utils.object_ids import resolve_object_id
+else:  # pragma: no cover - handles ``uvicorn main:app`` when cwd==api/
+    from app.db import get_db
+    from app.services.gemini_client import (  # type: ignore
+        GeminiConfigurationError,
+        GeminiGenerationError,
+        generate_insight,
+    )
+    from app.services.insight_facts import build_daily_facts, build_monthly_facts  # type: ignore
+    from app.utils.broadcast import broadcast_event  # type: ignore
+    from app.utils.object_ids import resolve_object_id  # type: ignore
+
+router = APIRouter(prefix="/insights", tags=["insights"])
+
+
+def _parse_object_id(value: str, field: str):
+    try:
+        return resolve_object_id(value, field)
+    except ValueError as exc:  # pragma: no cover - defensive guard
+        raise HTTPException(status_code=400, detail=f"Invalid {field}") from exc
+
+
+def _hash_facts(facts: Dict[str, Any]) -> str:
+    canonical = json.dumps(facts, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _cache_id(user_id: str, mode: str, key: str) -> str:
+    return f"{user_id}:{mode}:{key}"
+
+
+def _ensure_payload(value: Dict[str, Any]) -> Dict[str, Any]:
+    if not isinstance(value, dict):
+        raise HTTPException(status_code=502, detail="Gemini returned an invalid payload")
+    return value
+
+
+@router.get("/daily")
+async def daily_insight(
+    user_id: str = Query(..., description="User ID"),
+    date: str | None = Query(None, description="ISO date for the insight (defaults to today)"),
+    force: bool = Query(False, description="Force regeneration even if cached"),
+) -> Dict[str, Any]:
+    db = get_db()
+    user_oid = _parse_object_id(user_id, "user_id")
+
+    if date:
+        try:
+            reference = datetime.fromisoformat(date)
+        except ValueError as exc:  # pragma: no cover - defensive guard
+            raise HTTPException(status_code=400, detail="Invalid date format") from exc
+    else:
+        reference = datetime.utcnow()
+
+    facts = await build_daily_facts(db, user_oid, reference)
+    facts_hash = _hash_facts(facts)
+    cache_key = facts.get("day") or reference.date().isoformat()
+    cache_id = _cache_id(str(user_oid), "daily", cache_key)
+
+    cache = db.insights
+    cached = await cache.find_one({"_id": cache_id})
+    if cached and not force and cached.get("facts_hash") == facts_hash:
+        payload = cached.get("payload")
+        if isinstance(payload, dict):
+            return payload
+
+    try:
+        payload = await generate_insight(facts, "daily")
+    except GeminiConfigurationError as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
+    except GeminiGenerationError as exc:
+        raise HTTPException(status_code=502, detail=str(exc)) from exc
+
+    payload = _ensure_payload(payload)
+    now = datetime.utcnow()
+
+    await cache.update_one(
+        {"_id": cache_id},
+        {
+            "$set": {
+                "payload": payload,
+                "facts_hash": facts_hash,
+                "facts": facts,
+                "ts": now,
+            }
+        },
+        upsert=True,
+    )
+
+    await broadcast_event(
+        "insight_generated",
+        {"mode": "daily", "user_id": str(user_oid), "payload": payload, "facts": facts},
+    )
+
+    return payload
+
+
+@router.get("/monthly")
+async def monthly_insight(
+    user_id: str = Query(..., description="User ID"),
+    month: str | None = Query(None, description="Month in YYYY-MM format"),
+    force: bool = Query(False, description="Force regeneration even if cached"),
+) -> Dict[str, Any]:
+    db = get_db()
+    user_oid = _parse_object_id(user_id, "user_id")
+
+    if month:
+        try:
+            reference = datetime.fromisoformat(month + "-01")
+        except ValueError as exc:  # pragma: no cover - defensive guard
+            raise HTTPException(status_code=400, detail="Invalid month format") from exc
+    else:
+        reference = datetime.utcnow()
+
+    facts = await build_monthly_facts(db, user_oid, reference)
+    facts_hash = _hash_facts(facts)
+    cache_key = facts.get("month")
+    if not isinstance(cache_key, str):
+        cache_key = reference.strftime("%Y-%m")
+    cache_id = _cache_id(str(user_oid), "monthly", cache_key)
+
+    cache = db.insights
+    cached = await cache.find_one({"_id": cache_id})
+    if cached and not force and cached.get("facts_hash") == facts_hash:
+        payload = cached.get("payload")
+        if isinstance(payload, dict):
+            return payload
+
+    try:
+        payload = await generate_insight(facts, "monthly")
+    except GeminiConfigurationError as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
+    except GeminiGenerationError as exc:
+        raise HTTPException(status_code=502, detail=str(exc)) from exc
+
+    payload = _ensure_payload(payload)
+    now = datetime.utcnow()
+
+    await cache.update_one(
+        {"_id": cache_id},
+        {
+            "$set": {
+                "payload": payload,
+                "facts_hash": facts_hash,
+                "facts": facts,
+                "ts": now,
+            }
+        },
+        upsert=True,
+    )
+
+    await broadcast_event(
+        "insight_generated",
+        {"mode": "monthly", "user_id": str(user_oid), "payload": payload, "facts": facts},
+    )
+
+    return payload
+
+
+__all__ = ["router"]

--- a/api/main.py
+++ b/api/main.py
@@ -10,6 +10,7 @@ if __package__:
     from .habit_logs import alias_router as habit_logs_alias_router
     from .habit_logs import router as habit_logs_router
     from .habits import router as habits_router
+    from .insights import router as insights_router
     from .health import router as health_router
     from .schedule import alias_router as schedule_alias_router
     from .schedule import router as schedule_router
@@ -23,6 +24,7 @@ else:  # pragma: no cover - handles ``uvicorn main:app`` when cwd==api/
     from habit_logs import alias_router as habit_logs_alias_router
     from habit_logs import router as habit_logs_router
     from habits import router as habits_router
+    from insights import router as insights_router
     from health import router as health_router
     from schedule import alias_router as schedule_alias_router
     from schedule import router as schedule_router
@@ -57,6 +59,7 @@ def make_app() -> FastAPI:
         schedule_router,
         schedule_alias_router,
         summary_router,
+        insights_router,
         health_router,
     ]
 

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -5,3 +5,4 @@ motor>=3.4
 pydantic[email]>=2.7
 pydantic-core>=2.18
 typing-extensions>=4.12
+google-generativeai>=0.7


### PR DESCRIPTION
## Summary
- add Gemini client wrapper and fact builders to produce concise daily and monthly insight payloads
- expose cached /insights/daily and /insights/monthly endpoints that reuse stored payloads and broadcast updates
- configure Mongo indexes, environment settings, and dependency needed for Gemini access

## Testing
- python -m compileall api

------
https://chatgpt.com/codex/tasks/task_e_68ddf72bd66883268c29bcb53fd45fdf