### PR TITLE
Add autoschedule planner frontend integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,13 @@ The frontend opens a WebSocket connection at `ws://localhost:8000/ws/dashboard`.
 - No keys? The backend ships with a deterministic stub so local development always returns valid suggestions.
 - Feedback buttons in the modal POST to `/v1/ai/feedback`; monitor the `ai_feedback` collection to tune future prompts.
 
+### AI & Assistive Features
+- **Bulk task capture** – `/v1/tasks/bulk` lets you create multiple tasks in one request, perfect for command bar workflows.
+- **Autoschedule planner** – `/v1/scheduler/plan` returns a dry-run schedule using your free time. Pair the response with `/v1/schedule-events/bulk` to commit the plan.
+- **Smart splits** – `/v1/tasks/{task_id}/subtasks/bulk` (coming soon) appends generated subtasks to a task so you can break down big items quickly.
+- **Backlog healer** – `/v1/tasks/replan` (coming soon) proposes new due dates for overdue work.
+- **Habit coach feedback** – `/v1/ai/feedback` stores reinforcement signals when a habit feels too easy or too hard.
+
 ## API Endpoints
 
 ### Users
@@ -143,6 +150,8 @@ The frontend opens a WebSocket connection at `ws://localhost:8000/ws/dashboard`.
 - `POST /v1/schedule` - Create a simple scheduled item (summary, optional times/location)
 - `GET /v1/schedule-events` - List all schedule events with advanced filtering
 - `POST /v1/schedule-events` - Create a detailed schedule event (existing schema)
+- `POST /v1/schedule-events/bulk` - Create multiple scheduled blocks in a single request
+- `POST /v1/scheduler/plan` - Generate an autoschedule plan within a specified window
 
 ### Summary
 - `GET /v1/summary` - Return a synthesized daily briefing with counts used by the Alexa skill

--- a/api/app/services/__init__.py
+++ b/api/app/services/__init__.py
@@ -1,3 +1,5 @@
-"""Service helpers for AI-generated insights."""
+"""Service helpers for AI-generated insights and scheduling utilities."""
 
-__all__ = []
+from .freebusy import get_free_intervals
+
+__all__ = ["get_free_intervals"]

--- a/api/app/services/freebusy.py
+++ b/api/app/services/freebusy.py
@@ -1,0 +1,134 @@
+"""Utilities for computing free time windows for scheduling."""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import List
+
+from motor.motor_asyncio import AsyncIOMotorDatabase
+
+if __package__:
+    from ..utils.object_ids import resolve_object_id
+else:  # pragma: no cover
+    from app.utils.object_ids import resolve_object_id
+
+
+def _normalize_datetime(value: datetime) -> datetime:
+    """Normalise datetimes to naive UTC for storage comparisons."""
+
+    if value.tzinfo is not None:
+        return value.astimezone(timezone.utc).replace(tzinfo=None)
+    return value
+
+
+def _round_up(value: datetime, minutes: int) -> datetime:
+    """Round ``value`` up to the nearest ``minutes`` boundary."""
+
+    remainder_seconds = (value.minute * 60 + value.second) % (minutes * 60)
+    micro_adjust = -value.microsecond
+    if remainder_seconds == 0 and micro_adjust == 0:
+        return value.replace(microsecond=0)
+    delta_seconds = (minutes * 60) - remainder_seconds
+    return (value + timedelta(seconds=delta_seconds, microseconds=micro_adjust)).replace(microsecond=0)
+
+
+def _round_down(value: datetime, minutes: int) -> datetime:
+    """Round ``value`` down to the nearest ``minutes`` boundary."""
+
+    micro_adjusted = value - timedelta(microseconds=value.microsecond)
+    remainder_seconds = (micro_adjusted.minute * 60 + micro_adjusted.second) % (minutes * 60)
+    if remainder_seconds == 0:
+        return micro_adjusted
+    return micro_adjusted - timedelta(seconds=remainder_seconds)
+
+
+def _merge_ranges(ranges: List[tuple[datetime, datetime]]) -> List[tuple[datetime, datetime]]:
+    if not ranges:
+        return []
+
+    merged: List[tuple[datetime, datetime]] = []
+    current_start, current_end = ranges[0]
+    for start, end in ranges[1:]:
+        if start <= current_end:
+            if end > current_end:
+                current_end = end
+            continue
+        merged.append((current_start, current_end))
+        current_start, current_end = start, end
+    merged.append((current_start, current_end))
+    return merged
+
+
+async def get_free_intervals(
+    db: AsyncIOMotorDatabase,
+    user_id: str,
+    start: datetime,
+    end: datetime,
+    *,
+    block_minutes: int = 30,
+) -> List[dict[str, datetime]]:
+    """Return free intervals within ``[start, end]`` aligned to ``block_minutes``.
+
+    Busy periods are derived from ``schedule_events``. Returned intervals are
+    clamped to the input range and rounded to the nearest block boundary so
+    callers can allocate fixed-size blocks without overlapping existing events.
+    """
+
+    if block_minutes <= 0:
+        raise ValueError("block_minutes must be positive")
+
+    window_start = _normalize_datetime(start)
+    window_end = _normalize_datetime(end)
+    if window_start >= window_end:
+        return []
+
+    user_object_id = resolve_object_id(user_id, "user_id")
+
+    cursor = (
+        db.schedule_events.find(
+            {
+                "user_id": user_object_id,
+                "start_time": {"$lt": window_end},
+                "end_time": {"$gt": window_start},
+            },
+            {"start_time": 1, "end_time": 1, "_id": 0},
+        )
+        .sort("start_time", 1)
+    )
+
+    busy: List[tuple[datetime, datetime]] = []
+    async for doc in cursor:
+        start_time = doc.get("start_time")
+        end_time = doc.get("end_time")
+        if not isinstance(start_time, datetime) or not isinstance(end_time, datetime):
+            continue
+        normalized_start = _normalize_datetime(start_time)
+        normalized_end = _normalize_datetime(end_time)
+        if normalized_end <= normalized_start:
+            continue
+        busy.append((normalized_start, normalized_end))
+
+    busy.sort(key=lambda item: item[0])
+    merged_busy = _merge_ranges(busy)
+
+    raw_free: List[tuple[datetime, datetime]] = []
+    cursor_time = window_start
+    for busy_start, busy_end in merged_busy:
+        if busy_start > cursor_time:
+            free_end = min(busy_start, window_end)
+            if free_end > cursor_time:
+                raw_free.append((cursor_time, free_end))
+        cursor_time = max(cursor_time, busy_end)
+        if cursor_time >= window_end:
+            break
+    if cursor_time < window_end:
+        raw_free.append((cursor_time, window_end))
+
+    aligned: List[dict[str, datetime]] = []
+    for free_start, free_end in raw_free:
+        slot_start = _round_up(free_start, block_minutes)
+        slot_end = _round_down(free_end, block_minutes)
+        if slot_start >= slot_end:
+            continue
+        aligned.append({"start": slot_start, "end": slot_end})
+
+    return aligned

--- a/api/main.py
+++ b/api/main.py
@@ -15,6 +15,7 @@ if __package__:
     from .schedule import alias_router as schedule_alias_router
     from .schedule import router as schedule_router
     from .routes.ai import router as ai_router
+    from .routes.scheduler import router as scheduler_router
     from .summary import router as summary_router
     from .tasks import router as tasks_router
     from .users import router as users_router
@@ -30,6 +31,7 @@ else:  # pragma: no cover - handles ``uvicorn main:app`` when cwd==api/
     from schedule import alias_router as schedule_alias_router
     from schedule import router as schedule_router
     from routes.ai import router as ai_router
+    from routes.scheduler import router as scheduler_router
     from summary import router as summary_router
     from tasks import router as tasks_router
     from users import router as users_router
@@ -64,6 +66,7 @@ def make_app() -> FastAPI:
         insights_router,
         health_router,
         ai_router,
+        scheduler_router,
     ]
 
     # Legacy routes without versioning for compatibility

--- a/api/routes/scheduler.py
+++ b/api/routes/scheduler.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import math
+from datetime import datetime, timedelta
+from typing import List, Literal
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, Field
+
+try:  # Pydantic v2
+    from pydantic import ConfigDict
+except ImportError:  # pragma: no cover
+    ConfigDict = None  # type: ignore
+
+if __package__:
+    from ..app.db import get_db
+    from ..app.services.freebusy import get_free_intervals
+else:  # pragma: no cover - handles ``uvicorn main:app`` when cwd==api/
+    from app.db import get_db
+    from app.services.freebusy import get_free_intervals
+
+router = APIRouter(prefix="/scheduler", tags=["scheduler"])
+
+
+class PlanTask(BaseModel):
+    id: str = Field(alias="_id", description="Task identifier")
+    duration_minutes: int = Field(..., gt=0, description="Requested duration in minutes")
+
+    if ConfigDict is not None:  # pragma: no branch - guarded import
+        model_config = ConfigDict(populate_by_name=True)
+    else:  # pragma: no cover - Pydantic v1 fallback
+        class Config:
+            allow_population_by_field_name = True
+
+
+class PlanWindow(BaseModel):
+    start: datetime
+    end: datetime
+
+
+class PlanIn(BaseModel):
+    user_id: str = Field(..., description="User identifier or alias")
+    tasks: List[PlanTask] = Field(default_factory=list)
+    window: PlanWindow
+    strategy: Literal["first_fit"] = "first_fit"
+    block_minutes: int = Field(30, gt=0, le=240, description="Granularity used for scheduling suggestions")
+
+
+class PlanBlock(BaseModel):
+    task_id: str
+    start_time: datetime
+    end_time: datetime
+
+
+class PlanOut(BaseModel):
+    blocks: List[PlanBlock] = Field(default_factory=list)
+    overflow: List[str] = Field(default_factory=list)
+
+
+@router.post("/plan", response_model=PlanOut)
+async def scheduler_plan(payload: PlanIn) -> PlanOut:
+    """Propose schedule blocks for the supplied tasks using a greedy first-fit algorithm."""
+
+    if payload.window.start >= payload.window.end:
+        raise HTTPException(status_code=400, detail="Invalid planning window")
+
+    if not payload.tasks:
+        return PlanOut()
+
+    db = get_db()
+
+    free_intervals = await get_free_intervals(
+        db,
+        payload.user_id,
+        payload.window.start,
+        payload.window.end,
+        block_minutes=payload.block_minutes,
+    )
+
+    if not free_intervals:
+        return PlanOut(blocks=[], overflow=[task.id for task in payload.tasks])
+
+    # Copy so we can mutate as we consume availability.
+    intervals = [interval.copy() for interval in free_intervals]
+    blocks: List[PlanBlock] = []
+    overflow: List[str] = []
+
+    block_seconds = payload.block_minutes * 60
+
+    for task in payload.tasks:
+        required_slots = math.ceil((task.duration_minutes * 60) / block_seconds)
+        required_seconds = max(block_seconds, required_slots * block_seconds)
+        required_duration = timedelta(seconds=required_seconds)
+
+        assigned = False
+        for interval in intervals:
+            available = interval["end"] - interval["start"]
+            if available >= required_duration:
+                start_at = interval["start"]
+                end_at = start_at + required_duration
+                blocks.append(PlanBlock(task_id=task.id, start_time=start_at, end_time=end_at))
+                interval["start"] = end_at
+                assigned = True
+                break
+        if not assigned:
+            overflow.append(task.id)
+
+    return PlanOut(blocks=blocks, overflow=overflow)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -28,6 +28,7 @@ import AlexaTab from './components/tabs/AlexaTab';
 import { useDemoUser } from '@/hooks/useDemoUser';
 import { useTasks } from '@/hooks/useTasks';
 import { useHabits } from '@/hooks/useHabits';
+import { env } from '@/lib/env';
 
 const TABS = [
   { id: 'overview', label: 'Overview', icon: FiGrid },
@@ -72,6 +73,7 @@ function App() {
   );
 
   const isLoading = isUserLoading && !user;
+  const activeUserId = user?._id ?? env.DEMO_USER_ID;
 
   const initials = useMemo(() => {
     if (!user?.name) return 'DR';
@@ -213,7 +215,11 @@ function App() {
                 <HabitsTab />
               </TabPanel>
               <TabPanel px={0}>
-                <ScheduleTab />
+                <ScheduleTab
+                  tasks={incompleteTasks}
+                  isTasksLoading={isTasksLoading}
+                  userId={activeUserId}
+                />
               </TabPanel>
               <TabPanel px={0}>
                 <InsightsTab />

--- a/frontend/src/api/clients.ts
+++ b/frontend/src/api/clients.ts
@@ -1,0 +1,61 @@
+import { api } from '@/lib/api-client';
+import type { ScheduleEvent } from '@/types';
+
+export type PlanTaskInput = {
+  _id: string;
+  duration_minutes: number;
+};
+
+export type PlanWindowInput = {
+  start: string;
+  end: string;
+};
+
+export type PlanSchedulePayload = {
+  user_id: string;
+  tasks: PlanTaskInput[];
+  window: PlanWindowInput;
+  block_minutes?: number;
+};
+
+export type PlanScheduleResponse = {
+  blocks: Array<{
+    task_id: string;
+    start_time: string;
+    end_time: string;
+  }>;
+  overflow: string[];
+};
+
+export type BulkScheduleBlock = {
+  summary: string;
+  start_time: string;
+  end_time: string;
+  description?: string;
+  location?: string;
+  task_id?: string;
+};
+
+export type BulkSchedulePayload = {
+  user_id: string;
+  blocks: BulkScheduleBlock[];
+};
+
+export type BulkScheduleResponse = {
+  inserted: number;
+  items: ScheduleEvent[];
+};
+
+export async function planSchedule(
+  payload: PlanSchedulePayload
+): Promise<PlanScheduleResponse> {
+  const { data } = await api.post<PlanScheduleResponse>('/scheduler/plan', payload);
+  return data;
+}
+
+export async function createScheduleBulk(
+  payload: BulkSchedulePayload
+): Promise<BulkScheduleResponse> {
+  const { data } = await api.post<BulkScheduleResponse>('/schedule-events/bulk', payload);
+  return data;
+}

--- a/frontend/src/components/AutoschedulePlanner.tsx
+++ b/frontend/src/components/AutoschedulePlanner.tsx
@@ -1,0 +1,391 @@
+import {
+  Badge,
+  Box,
+  Button,
+  Checkbox,
+  Divider,
+  FormControl,
+  FormLabel,
+  HStack,
+  Input,
+  NumberDecrementStepper,
+  NumberIncrementStepper,
+  NumberInput,
+  NumberInputField,
+  NumberInputStepper,
+  Skeleton,
+  Stack,
+  Text,
+  VStack,
+  useColorModeValue,
+  useToast,
+} from '@chakra-ui/react';
+import dayjs from 'dayjs';
+import utc from 'dayjs/plugin/utc';
+import { useMemo, useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { createScheduleBulk, planSchedule } from '@/api/clients';
+import { env } from '@/lib/env';
+import type { Task } from '@/types';
+import CardContainer from './ui/CardContainer';
+
+dayjs.extend(utc);
+
+type AutoschedulePlannerProps = {
+  tasks: Task[];
+  userId?: string;
+  isTasksLoading?: boolean;
+};
+
+type SelectedDurations = Record<string, number>;
+
+type PlanState = {
+  blocks: Array<{ task_id: string; start_time: string; end_time: string }>;
+  overflow: string[];
+} | null;
+
+const MIN_DURATION = 15;
+const MAX_DURATION = 240;
+const STEP_DURATION = 15;
+
+const AutoschedulePlanner = ({ tasks, userId = env.DEMO_USER_ID, isTasksLoading }: AutoschedulePlannerProps) => {
+  const [selectedDurations, setSelectedDurations] = useState<SelectedDurations>({});
+  const [windowStart, setWindowStart] = useState(() =>
+    toDateTimeLocal(dayjs().startOf('day').add(9, 'hour'))
+  );
+  const [windowEnd, setWindowEnd] = useState(() =>
+    toDateTimeLocal(dayjs().add(1, 'day').startOf('day').add(18, 'hour'))
+  );
+  const [isPlanning, setIsPlanning] = useState(false);
+  const [isCommitting, setIsCommitting] = useState(false);
+  const [plan, setPlan] = useState<PlanState>(null);
+  const toast = useToast();
+  const queryClient = useQueryClient();
+  const listBg = useColorModeValue('bg.secondary', 'whiteAlpha.100');
+  const listBorder = useColorModeValue('border.subtle', 'whiteAlpha.200');
+
+  const selectedTasks = useMemo(() =>
+    tasks.filter((task) => selectedDurations[task._id] != null),
+    [tasks, selectedDurations]
+  );
+
+  const tasksById = useMemo(() => {
+    const mapping: Record<string, Task> = {};
+    for (const task of tasks) {
+      mapping[task._id] = task;
+    }
+    return mapping;
+  }, [tasks]);
+
+  const canPlan = selectedTasks.length > 0 && windowStart && windowEnd;
+
+  const handleToggleTask = (taskId: string, isChecked: boolean) => {
+    setPlan(null);
+    setSelectedDurations((prev) => {
+      const next = { ...prev };
+      if (isChecked) {
+        next[taskId] = prev[taskId] ?? 30;
+      } else {
+        delete next[taskId];
+      }
+      return next;
+    });
+  };
+
+  const handleDurationChange = (taskId: string, value: number) => {
+    setPlan(null);
+    setSelectedDurations((prev) => ({
+      ...prev,
+      [taskId]: Math.max(MIN_DURATION, Math.min(MAX_DURATION, value || MIN_DURATION)),
+    }));
+  };
+
+  const handlePlan = async () => {
+    if (!canPlan || !userId) return;
+    const start = dayjs(windowStart);
+    const end = dayjs(windowEnd);
+
+    if (!start.isValid() || !end.isValid()) {
+      toast({ title: 'Enter a valid planning window', status: 'warning' });
+      return;
+    }
+
+    if (start.isAfter(end)) {
+      toast({ title: 'Check your planning window', status: 'warning' });
+      return;
+    }
+
+    setIsPlanning(true);
+    try {
+      const response = await planSchedule({
+        user_id: userId,
+        window: { start: start.toISOString(), end: end.toISOString() },
+        tasks: selectedTasks.map((task) => ({
+          _id: task._id,
+          duration_minutes: selectedDurations[task._id],
+        })),
+        block_minutes: STEP_DURATION,
+      });
+      setPlan(response);
+      if (response.blocks.length === 0) {
+        toast({ title: 'No available time slots found', status: 'info' });
+      }
+    } catch (error) {
+      console.error(error);
+      toast({ title: 'Could not generate a schedule', status: 'error' });
+    } finally {
+      setIsPlanning(false);
+    }
+  };
+
+  const handleCommit = async () => {
+    if (!plan || plan.blocks.length === 0 || !userId) return;
+
+    setIsCommitting(true);
+    try {
+      await createScheduleBulk({
+        user_id: userId,
+        blocks: plan.blocks.map((block) => {
+          const task = tasksById[block.task_id];
+          const summary = task?.description ?? 'Scheduled focus block';
+          return {
+            summary,
+            start_time: block.start_time,
+            end_time: block.end_time,
+            task_id: block.task_id,
+            description: task?.description,
+          };
+        }),
+      });
+      await queryClient.invalidateQueries({ queryKey: ['schedule', userId] });
+      toast({ title: 'Schedule saved', status: 'success' });
+      setPlan(null);
+      setSelectedDurations({});
+    } catch (error) {
+      console.error(error);
+      toast({ title: 'Could not save events', status: 'error' });
+    } finally {
+      setIsCommitting(false);
+    }
+  };
+
+  return (
+    <CardContainer surface="muted">
+      <Stack spacing={6} position="relative" zIndex={1}>
+        <Stack spacing={1}>
+          <Text fontSize="lg" fontWeight="semibold" color="text.primary">
+            Autoschedule selected tasks
+          </Text>
+          <Text fontSize="sm" color="text.secondary">
+            Pick tasks, choose a window, and let DailyRoutine find the focus blocks for you.
+          </Text>
+        </Stack>
+
+        <Stack spacing={3}>
+          <FormControl>
+            <FormLabel fontSize="sm">Planning window start</FormLabel>
+            <Input
+              type="datetime-local"
+              value={windowStart}
+              onChange={(event) => setWindowStart(event.target.value)}
+              borderRadius="14px"
+            />
+          </FormControl>
+          <FormControl>
+            <FormLabel fontSize="sm">Planning window end</FormLabel>
+            <Input
+              type="datetime-local"
+              value={windowEnd}
+              onChange={(event) => setWindowEnd(event.target.value)}
+              borderRadius="14px"
+            />
+          </FormControl>
+        </Stack>
+
+        <Stack spacing={3}>
+          <Text fontWeight="semibold" fontSize="sm" color="text.secondary">
+            Select tasks to include
+          </Text>
+          {isTasksLoading ? (
+            <Stack spacing={3}>
+              {Array.from({ length: 3 }).map((_, index) => (
+                <Skeleton key={index} height="56px" borderRadius="16px" />
+              ))}
+            </Stack>
+          ) : tasks.length === 0 ? (
+            <Box
+              borderRadius="16px"
+              borderWidth="1px"
+              borderColor={listBorder}
+              p={6}
+              textAlign="center"
+              bg={listBg}
+            >
+              <Text fontWeight="semibold">No tasks available</Text>
+              <Text fontSize="sm" color="text.secondary">
+                Create tasks first to generate a plan.
+              </Text>
+            </Box>
+          ) : (
+            <VStack spacing={3} align="stretch">
+              {tasks.map((task) => {
+                const isSelected = selectedDurations[task._id] != null;
+                return (
+                  <HStack
+                    key={task._id}
+                    spacing={4}
+                    align="center"
+                    justify="space-between"
+                    bg={listBg}
+                    borderRadius="16px"
+                    borderWidth="1px"
+                    borderColor={listBorder}
+                    p={4}
+                    flexWrap="wrap"
+                  >
+                    <Stack spacing={1} flex="1">
+                      <Checkbox
+                        isChecked={isSelected}
+                        onChange={(event) => handleToggleTask(task._id, event.target.checked)}
+                      >
+                        <Text fontWeight="medium" color="text.primary">
+                          {task.description}
+                        </Text>
+                      </Checkbox>
+                      {task.due_date && (
+                        <Badge alignSelf="flex-start" colorScheme="orange" variant="subtle">
+                          Due {dayjs(task.due_date).format('MMM D, h:mm A')}
+                        </Badge>
+                      )}
+                    </Stack>
+                    <Stack spacing={1} align="flex-end">
+                      <Text fontSize="xs" color="text.secondary">
+                        Duration (minutes)
+                      </Text>
+                      <NumberInput
+                        size="sm"
+                        maxW="120px"
+                        min={MIN_DURATION}
+                        max={MAX_DURATION}
+                        step={STEP_DURATION}
+                        value={selectedDurations[task._id] ?? MIN_DURATION}
+                        isDisabled={!isSelected}
+                        onChange={(_, value) => handleDurationChange(task._id, value)}
+                      >
+                        <NumberInputField borderRadius="12px" />
+                        <NumberInputStepper>
+                          <NumberIncrementStepper />
+                          <NumberDecrementStepper />
+                        </NumberInputStepper>
+                      </NumberInput>
+                    </Stack>
+                  </HStack>
+                );
+              })}
+            </VStack>
+          )}
+        </Stack>
+
+        <HStack spacing={3}>
+          <Button
+            colorScheme="orange"
+            onClick={handlePlan}
+            isDisabled={!canPlan}
+            isLoading={isPlanning}
+          >
+            Plan schedule
+          </Button>
+          {plan && (
+            <Button
+              variant="ghost"
+              onClick={() => setPlan(null)}
+              isDisabled={isPlanning || isCommitting}
+            >
+              Clear
+            </Button>
+          )}
+        </HStack>
+
+        {plan && (
+          <Stack spacing={4}>
+            <Divider />
+            <Stack spacing={2}>
+              <Text fontWeight="semibold" color="text.primary">
+                Suggested blocks
+              </Text>
+              {plan.blocks.length === 0 ? (
+                <Text fontSize="sm" color="text.secondary">
+                  No openings were found in the selected window.
+                </Text>
+              ) : (
+                <VStack align="stretch" spacing={3}>
+                  {plan.blocks.map((block) => {
+                    const task = tasksById[block.task_id];
+                    return (
+                      <Box
+                        key={`${block.task_id}-${block.start_time}`}
+                        borderRadius="14px"
+                        borderWidth="1px"
+                        borderColor={listBorder}
+                        bg={listBg}
+                        p={4}
+                      >
+                        <Text fontWeight="medium" color="text.primary">
+                          {task?.description ?? 'Task'}
+                        </Text>
+                        <Text fontSize="sm" color="text.secondary">
+                          {dayjs(block.start_time).format('MMM D, h:mm A')} –{' '}
+                          {dayjs(block.end_time).format('h:mm A')}
+                        </Text>
+                      </Box>
+                    );
+                  })}
+                </VStack>
+              )}
+            </Stack>
+            {plan.overflow.length > 0 && (
+              <Stack spacing={2}>
+                <Text fontWeight="semibold" color="text.primary">
+                  Overflow
+                </Text>
+                <Text fontSize="sm" color="text.secondary">
+                  Could not fit {plan.overflow.length} task(s):
+                </Text>
+                <VStack align="stretch" spacing={2}>
+                  {plan.overflow.map((taskId) => (
+                    <Text key={taskId} fontSize="sm" color="text.secondary">
+                      • {tasksById[taskId]?.description ?? taskId}
+                    </Text>
+                  ))}
+                </VStack>
+              </Stack>
+            )}
+            {plan.blocks.length > 0 && (
+              <Button
+                alignSelf="flex-start"
+                colorScheme="orange"
+                onClick={handleCommit}
+                isLoading={isCommitting}
+              >
+                Save to calendar
+              </Button>
+            )}
+          </Stack>
+        )}
+      </Stack>
+      <Box
+        position="absolute"
+        inset={0}
+        opacity={0.12}
+        backgroundImage="radial-gradient(circle at 20% 20%, rgba(249, 115, 22, 0.18), transparent 60%)"
+        pointerEvents="none"
+      />
+    </CardContainer>
+  );
+};
+
+function toDateTimeLocal(value: dayjs.Dayjs) {
+  return value.local().format('YYYY-MM-DDTHH:mm');
+}
+
+export default AutoschedulePlanner;

--- a/frontend/src/components/ScheduleCard.tsx
+++ b/frontend/src/components/ScheduleCard.tsx
@@ -28,10 +28,11 @@ dayjs.extend(localizedFormat);
 
 type ScheduleCardProps = {
   layout: 'row' | 'column';
+  userId?: string;
 };
 
-const ScheduleCard = ({ layout }: ScheduleCardProps) => {
-  const { data: events = [], isLoading } = useSchedule();
+const ScheduleCard = ({ layout, userId = env.DEMO_USER_ID }: ScheduleCardProps) => {
+  const { data: events = [], isLoading } = useSchedule(userId);
   const aiDisclosure = useDisclosure();
   const [activeEvent, setActiveEvent] = useState<ScheduleEvent | null>(null);
   const queryClient = useQueryClient();

--- a/frontend/src/components/tabs/InsightsTab.tsx
+++ b/frontend/src/components/tabs/InsightsTab.tsx
@@ -48,6 +48,9 @@ const InsightsTab = () => {
     refetch: refetchMonthly
   } = useMonthlyInsight(user?._id || '', monthlyDate || undefined, forceRefresh);
 
+  const normalizedDailyError = (dailyError as Error | null | undefined) ?? null;
+  const normalizedMonthlyError = (monthlyError as Error | null | undefined) ?? null;
+
   const tabListBg = useColorModeValue('rgba(255, 255, 255, 0.88)', 'whiteAlpha.100');
   const tabColor = useColorModeValue('text.muted', 'whiteAlpha.800');
   const selectedTabStyles = useColorModeValue(
@@ -191,7 +194,7 @@ const InsightsTab = () => {
                 <InsightsCard
                   title="Today's AI Insights"
                   isLoading={isDailyLoading}
-                  error={dailyError}
+                  error={normalizedDailyError}
                   onRefresh={handleRefresh}
                 >
                   {dailyInsight && <DailyInsightContent insight={dailyInsight} />}
@@ -240,7 +243,7 @@ const InsightsTab = () => {
                 <InsightsCard
                   title="Monthly AI Insights"
                   isLoading={isMonthlyLoading}
-                  error={monthlyError}
+                  error={normalizedMonthlyError}
                   onRefresh={handleRefresh}
                 >
                   {monthlyInsight && <MonthlyInsightContent insight={monthlyInsight} />}

--- a/frontend/src/components/tabs/ScheduleTab.tsx
+++ b/frontend/src/components/tabs/ScheduleTab.tsx
@@ -1,13 +1,25 @@
-import { Box, useBreakpointValue } from '@chakra-ui/react';
+import { Box, Stack, useBreakpointValue } from '@chakra-ui/react';
+import AutoschedulePlanner from '../AutoschedulePlanner';
 import ScheduleCard from '../ScheduleCard';
+import type { Task } from '@/types';
+import { env } from '@/lib/env';
 
-const ScheduleTab = () => {
+type ScheduleTabProps = {
+  tasks: Task[];
+  isTasksLoading: boolean;
+  userId?: string;
+};
+
+const ScheduleTab = ({ tasks, isTasksLoading, userId = env.DEMO_USER_ID }: ScheduleTabProps) => {
   const layout = useBreakpointValue<'column' | 'row'>({ base: 'column', lg: 'row' });
 
   return (
-    <Box maxW="4xl" mx="auto">
-      <ScheduleCard layout={layout ?? 'column'} />
-    </Box>
+    <Stack spacing={8} maxW="5xl" mx="auto">
+      <Box>
+        <ScheduleCard layout={layout ?? 'column'} userId={userId} />
+      </Box>
+      <AutoschedulePlanner tasks={tasks} userId={userId} isTasksLoading={isTasksLoading} />
+    </Stack>
   );
 };
 


### PR DESCRIPTION
## Summary
- add frontend API helpers for scheduler planning and bulk schedule creation
- introduce an AutoschedulePlanner component that lets users select tasks, preview proposed blocks, and commit them to the calendar
- wire the planner into the schedule tab with user-aware queries and tidy type handling for existing insights errors

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68df3bec739c8326a211c1f19498e746