### PR TITLE
Improve overview filtering, habit logging, and task creation

### DIFF
--- a/frontend/src/components/HabitBoard.tsx
+++ b/frontend/src/components/HabitBoard.tsx
@@ -278,7 +278,7 @@ const handleLogHabit = (
   mutation.mutate(
     {
       habit_id: habit._id,
-      date: new Date().toISOString(),
+      date: dayjs().format('YYYY-MM-DD'),
       status,
       completed_repetitions: status === 'completed' ? 1 : 0,
     },

--- a/frontend/src/components/tabs/OverviewTab.tsx
+++ b/frontend/src/components/tabs/OverviewTab.tsx
@@ -1,8 +1,7 @@
 import { Grid, GridItem } from '@chakra-ui/react';
-import { useMemo } from 'react';
 import GreetingCard from '../GreetingCard';
 import AIPlanCard from '../AIPlanCard';
-import type { Habit, HabitLog, Task, User, ProgressSummary } from '@/types';
+import type { Habit, HabitLog, Task, User } from '@/types';
 import { useTasks } from '@/hooks/useTasks';
 import { useHabitLogs } from '@/hooks/useHabits';
 import { useSchedule } from '@/hooks/useSchedule';
@@ -22,26 +21,20 @@ const OverviewTab = ({ user, tasks, habits, isTasksLoading, isHabitsLoading }: O
   const { data: habitLogs = [], isLoading: isHabitLogsLoading } = useHabitLogs();
   const { data: scheduleEvents = [], isLoading: isScheduleLoading } = useSchedule();
 
-  const progress = useMemo<ProgressSummary>(() => {
-    const todaysLogs = getTodaysHabitLogs(habitLogs);
-    const completedHabitIds = new Set(
-      todaysLogs.filter((log) => log.status === 'completed').map((log) => log.habit_id)
-    );
-    return {
-      tasks_completed: completedTasks.length,
-      tasks_total: completedTasks.length + tasks.length,
-      habits_completed: [...completedHabitIds].length,
-      habits_total: habits.length,
-    };
-  }, [completedTasks.length, habitLogs, habits.length, tasks.length]);
-
   const summaryLoading =
     isTasksLoading || isHabitsLoading || isCompletedLoading || isHabitLogsLoading || isScheduleLoading;
 
   return (
     <Grid templateColumns={{ base: '1fr', lg: 'repeat(6, 1fr)' }} gap={{ base: 6, lg: 8 }} alignItems="stretch">
       <GridItem colSpan={{ base: 1, lg: 4 }}>
-        <GreetingCard user={user} progress={progress} isLoading={summaryLoading} />
+        <GreetingCard
+          user={user}
+          tasks={tasks}
+          completedTasks={completedTasks}
+          habits={habits}
+          habitLogs={habitLogs}
+          isLoading={summaryLoading}
+        />
       </GridItem>
       <GridItem colSpan={{ base: 1, lg: 2 }}>
         <AIPlanCard
@@ -55,10 +48,5 @@ const OverviewTab = ({ user, tasks, habits, isTasksLoading, isHabitsLoading }: O
     </Grid>
   );
 };
-
-function getTodaysHabitLogs(logs: HabitLog[]) {
-  const today = new Date().toISOString().slice(0, 10);
-  return logs.filter((log) => log.date.slice(0, 10) === today);
-}
 
 export default OverviewTab;


### PR DESCRIPTION
## Summary
- make the overview quick-action controls interactive with darker styling and optional custom date ranges while recalculating stats per range
- ensure habit logs record the local calendar date to avoid drifting to the next day
- add a manual task creation modal/button and correct toggle handling in the tasks board alongside AI generation

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68df746adc188326b8966a432a534b28